### PR TITLE
Show uploadDocumentFile as deprecated, tidy URLs

### DIFF
--- a/fern/definition/documentCatalog.yml
+++ b/fern/definition/documentCatalog.yml
@@ -4,7 +4,7 @@ service:
   endpoints:
     uploadDocumentUrl:
       path: /uploadDocumentUrl
-      docs: Upload a document using its url.
+      docs: Upload a document using its URL.
       method: POST
       request:
         name: UploadDocumentUrlRequest
@@ -13,7 +13,7 @@ service:
             documentUrl:
               type: string
               docs: |
-                The url for the document you want to upload. Credal will automatically connect 
+                The URL for the document you want to upload. Credal will automatically connect 
                 to source systems like Google Drive, Office 365, Confluence, etc. to fetch 
                 and upload the document contents.
       response: UploadDocumentResponse
@@ -50,7 +50,7 @@ service:
             documentExternalUrl:
               type: optional<string>
               docs: /
-                The external url of the document you want to upload. If provided Credal will link to this url.
+                The external URL of the document you want to upload. If provided Credal will link to this URL.
             customMetadata:
               type: optional<unknown>
               docs: /
@@ -80,6 +80,7 @@ service:
     uploadDocumentFile:
       path: /uploadDocumentFile
       method: POST
+      availability: deprecated
       request:
         name: UploadDocumentFileRequest
         body:


### PR DESCRIPTION
show uploading files as deprecated (triggered by mongo discussions), dont want to implement it and 99% of the time it should be uploadDocumentContents anyway