### PR TITLE
Make "operator" Operator, show legacy search field to not spook mongo people

### DIFF
--- a/fern/definition/search.yml
+++ b/fern/definition/search.yml
@@ -25,8 +25,8 @@ service:
             searchOptions:
               type: optional<DocumentCollectionSearchOptions>
             metadataFilterExpression:
-              type: optional<string>
               availability: deprecated
+              type: optional<string>
               docs: |
                 Legacy metadata filter expression to apply to the search query. Use structuredQueryFilters instead.
       response: SearchDocumentCollectionResponse


### PR DESCRIPTION
Deprecated not showing up, thread here
https://discord.com/channels/988611740499574794/988611741476859916/1238139865955176528