### PR TITLE
:herb: upgrade Python generator

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -18,7 +18,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 2.2.0
+        version: 2.7.0
         output: 
           location: pypi
           package-name: "credal"
@@ -29,7 +29,7 @@ groups:
   python-local:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 2.2.0
+        version: 2.7.0
         output:
           location: local-file-system
           path: ../generated/python


### PR DESCRIPTION
This addresses the issue with serializing deep object query parameters

Changelog here: https://github.com/fern-api/fern/blob/main/generators/python/sdk/CHANGELOG.md
(Specifically this was fixed in version [2.3.2](https://github.com/fern-api/fern/blob/main/generators/python/sdk/CHANGELOG.md#232---2024-05-21))