### PR TITLE
fix(snippets): regenerate docs after generating SDKs

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -27,3 +27,9 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN}}
         run: |
           fern generate --group python-sdk --version ${{ inputs.version }} --log-level debug
+
+      - name: Regenerate Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          fern generate --docs


### PR DESCRIPTION
Need to do this in TypeScript SDK as well