### PR TITLE
Add beta tag to streaming endpoint

### DIFF
--- a/fern/definition/copilots.yml
+++ b/fern/definition/copilots.yml
@@ -198,6 +198,7 @@ service:
                 messageId: dd721cd8-4bf2-4b94-9869-258df3dab9dc
 
     streamMessage:
+      availability: pre-release
       docs: |
         This endpoint allows you to send a message to a specific copilot and get the response back as a streamed set of Server-Sent Events.
       path: /streamMessage


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add pre-release availability tag to `streamMessage` endpoint in `copilots.yml`.
> 
>   - **Behavior**:
>     - Add `availability: pre-release` to `streamMessage` endpoint in `copilots.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for 837884ece41454409adb4de357b9a4bfbc877cf6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->