### PR TITLE
Fix typescript sdk script

### DIFF
--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -25,8 +25,8 @@ jobs:
         run: |
           fern generate --group typescript-sdk --version ${{ inputs.version }} --log-level debug
 
-        - name: Regenerate Docs
-          env:
-            FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-          run: |
-            fern generate --docs          
+      - name: Regenerate Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          fern generate --docs          


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix indentation for 'Regenerate Docs' step in `typescript-sdk.yml` workflow file.
> 
>   - **Fix**:
>     - Correct indentation for 'Regenerate Docs' step in `.github/workflows/typescript-sdk.yml` to align with other steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for a5fd02a1347e6fcebac27db5d489f3477b464bcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->