### PR TITLE
Fix fern types to account for weird SSE limitations

### DIFF
--- a/fern/definition/copilots.yml
+++ b/fern/definition/copilots.yml
@@ -250,7 +250,8 @@ service:
           response:
             stream:
               - event: initial
-                data: 
+                data:
+                  event: initial
                   conversationId: fc938005-92db-411a-88eb-32ca50d5f744
                   webSearchResults: 
                     [
@@ -262,16 +263,20 @@ service:
                     ]
                   warnings: []
               - event: data_chunk
-                data: 
+                data:
+                  event: data_chunk
                   chunk: Based on 
               - event: data_chunk
-                data: 
+                data:
+                  event: data_chunk 
                   chunk: the context provided, 
               - event: data_chunk
-                data: 
+                data:
+                  event: data_chunk 
                   chunk: Credal is SOC 2 compliant.
               - event: final_chunk
-                data: 
+                data:
+                  event: final_chunk 
                   sources:
                     [
                       {
@@ -301,7 +306,8 @@ service:
           response:
             stream:
               - event: blocked
-                data: 
+                data:
+                  event: blocked 
                   conversationId: fc938005-92db-411a-88eb-32ca50d5f744
                   policyTriggers: []
                   warnings: []
@@ -582,9 +588,9 @@ types:
       policyTriggers: list<PolicyTrigger>
 
   StreamingChunk:
-    discriminated: false
+    discriminant: event
     union:
-      - InitialChunk
-      - DataChunk
-      - FinalChunk
-      - BlockedChunk
+      initial: InitialChunk
+      data_chunk: DataChunk
+      final_chunk: FinalChunk
+      blocked: BlockedChunk


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `event` field to stream events and update `StreamingChunk` type in `copilots.yml` to handle SSE limitations.
> 
>   - **Behavior**:
>     - Add `event` field to `data` in stream events in `copilots.yml` to explicitly specify event type.
>     - Update `StreamingChunk` type to use `event` as discriminant for union.
>   - **Types**:
>     - Modify `StreamingChunk` union to map `initial`, `data_chunk`, `final_chunk`, and `blocked` to respective chunk types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for 647a005ff844b1c27ed615b10ae7ee94189e3adb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->