### PR TITLE
Fixed squeezed images

### DIFF
--- a/fern/docs/pages/guides/copilots/quick-start.mdx
+++ b/fern/docs/pages/guides/copilots/quick-start.mdx
@@ -11,8 +11,9 @@ From the main screen, click “Copilots” in the navigation menu:
 
 {/* this */}
 
-{" "}
-<img src="/docs/assets/copilots/copilots-link.png" width="150" />
+<Frame>
+  <img src="/docs/assets/copilots/copilots-link.png" />
+</Frame>
 
 Then click “Create Copilot”:
 

--- a/fern/docs/pages/guides/copilots/quick-start.mdx
+++ b/fern/docs/pages/guides/copilots/quick-start.mdx
@@ -9,8 +9,6 @@ You can then talk to them in a chat UI or deploy them to Slack or another applic
 
 From the main screen, click “Copilots” in the navigation menu:
 
-{/* this */}
-
 <Frame>
   <img src="/docs/assets/copilots/copilots-link.png" />
 </Frame>
@@ -24,7 +22,7 @@ Then click “Create Copilot”:
 Give your copilot a Name and add a Description of its function in the pop-out form. You can always come back and edit these later. _Descriptions should be detailed enough to describe what kind of queries the copilot is responsible for._
 
 <Frame>
-  <img src="/docs/assets/copilots/create-copilot-form.png" width="500" />
+  <img src="/docs/assets/copilots/create-copilot-form.png" />
 </Frame>
 
 You can click on “Copilots” in your left sidebar anytime to view the full list of Copilots you've created or that have been shared with you.
@@ -42,7 +40,7 @@ Now your copilot is set up, Credal will automatically direct you to the configur
 3. **Creativity**. We recommend starting with “balanced” or “precise”; “creative” is best for brainstorming, creative writing, or marketing use cases.
 
 <Frame>
-  <img src="/docs/assets/copilots/copilot-model-creativity.png" width="400" />
+  <img src="/docs/assets/copilots/copilot-model-creativity.png" />
 </Frame>
 
 4. **Prompt**

--- a/fern/docs/pages/guides/copilots/quick-start.mdx
+++ b/fern/docs/pages/guides/copilots/quick-start.mdx
@@ -9,9 +9,10 @@ You can then talk to them in a chat UI or deploy them to Slack or another applic
 
 From the main screen, click “Copilots” in the navigation menu:
 
-<Frame>
-  <img src="/docs/assets/copilots/copilots-link.png" width="150" />
-</Frame>
+{/* this */}
+
+{" "}
+<img src="/docs/assets/copilots/copilots-link.png" width="150" />
 
 Then click “Create Copilot”:
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed width attributes from image tags in `quick-start.mdx` for natural size display.
> 
>   - **Documentation**:
>     - Removed width attributes from image tags in `quick-start.mdx` to allow images to display at their natural size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for fe31ccb5093b1ff09c75a1967ad3ae4244868dda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->