### PR TITLE
Link to notion overall AI quickstart, system status, drop oauth noise

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,7 +1,7 @@
 instances:
   - url: credal.docs.buildwithfern.com
     custom-domain: docs.credal.ai
-    edit-this-page: 
+    edit-this-page:
       github:
         owner: Credal-ai
         repo: fern-docs
@@ -14,6 +14,8 @@ navigation:
     contents:
       - page: Overview
         path: ./docs/pages/guides/overview.mdx
+      - page: Getting Started with AI
+        path: https://credalai.notion.site/Credal-Quickstart-Guide-9f1d589bc51a461e9c9860c2180abc58
       - section: Copilots
         contents:
           - page: Quick Start

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,8 +14,8 @@ navigation:
     contents:
       - page: Overview
         path: ./docs/pages/guides/overview.mdx
-      - page: Getting Started with AI
-        path: https://credalai.notion.site/Credal-Quickstart-Guide-9f1d589bc51a461e9c9860c2180abc58
+      - link: Getting Started with AI
+        href: https://credalai.notion.site/Credal-Quickstart-Guide-9f1d589bc51a461e9c9860c2180abc58
       - section: Copilots
         contents:
           - page: Quick Start
@@ -48,6 +48,9 @@ navbar-links:
   - type: filled
     text: Start using Credal
     url: https://app.credal.ai/signin
+  - type: secondary
+    text: System Status
+    url: https://status.credal.ai
 
 colors:
   accentPrimary:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -28,8 +28,6 @@ navigation:
         path: ./docs/pages/guides/bulk-analysis.mdx
       - page: Permissions Service
         path: ./docs/pages/guides/permissions-service.mdx
-      - page: OAuth
-        path: ./docs/pages/guides/oauth.mdx
       - page: Prompting
         path: ./docs/pages/guides/prompting.mdx
       - page: Data Sources
@@ -45,12 +43,12 @@ navbar-links:
   - type: minimal
     text: Contact us
     url: mailto:support@credal.ai
-  - type: filled
-    text: Start using Credal
-    url: https://app.credal.ai/signin
   - type: secondary
     text: System Status
     url: https://status.credal.ai
+  - type: filled
+    text: Start using Credal
+    url: https://app.credal.ai/signin
 
 colors:
   accentPrimary:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,7 +14,7 @@ navigation:
     contents:
       - page: Overview
         path: ./docs/pages/guides/overview.mdx
-      - link: Getting Started with AI
+      - link: Credal Quick Start
         href: https://credalai.notion.site/Credal-Quickstart-Guide-9f1d589bc51a461e9c9860c2180abc58
       - section: Copilots
         contents:

--- a/fern/docs/pages/guides/oauth.mdx
+++ b/fern/docs/pages/guides/oauth.mdx
@@ -1,4 +1,0 @@
-<Callout intent="warning">
-  Credal's OAuth flow for API access is in private Beta.  Contact Credal to get started.
-</Callout>
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds "Credal Quick Start" link and "System Status" link to `docs.yml`, removes "OAuth" page.
> 
>   - **Navigation Changes**:
>     - Adds a link to "Credal Quick Start" in `docs.yml` navigation section.
>     - Removes "OAuth" page from `docs.yml` navigation.
>   - **Navbar Changes**:
>     - Adds "System Status" link to the navbar in `docs.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for cfe99b0876497c02194e7cc8f7f6edadfca38eb1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->