### PR TITLE
fix quickstart link 

### DIFF
--- a/fern/docs/pages/guides/actions/actions.mdx
+++ b/fern/docs/pages/guides/actions/actions.mdx
@@ -1,11 +1,12 @@
-_This is a comprehensive in depth guide for Actions. If you’re just getting started, check out [Getting Started With AI Copilots](/copilots/quick-start)._
+_This is a comprehensive in depth guide for Actions. If you’re just getting started, check out [Getting Started With AI Copilots](/getting-started/copilots/quick-start)._
 
-Credal Actions allow users to create well defined actions that copilots can then use proactively in helping you as your personal assistants. 
+Credal Actions allow users to create well defined actions that copilots can then use proactively in helping you as your personal assistants.
 
-Some basic examples of actions are: 
-- Address Validation 
+Some basic examples of actions are:
+
+- Address Validation
 - Updating Info on collaboration tools (Confluence, Google Drive)
-- Consulting with other copilots 
+- Consulting with other copilots
 
 Actions are a powerful tool to make your copilots even stronger than they already are.
 
@@ -35,7 +36,6 @@ Note: You can create custom actions to interface with your private internal syst
 
 ![copilot_actions_dialog](/docs/assets/actions/create-action-dialog.png)
 
-
 ## 2. **Configuring your Action**
 
 1. In this example we selected the `Validate Address on Google Maps` action, now we can see how to configure it.
@@ -60,17 +60,15 @@ Note: You can create custom actions to interface with your private internal syst
 
 ![copilot_actions_governance_modal](/docs/assets/actions/governance-modal.png)
 
-
 ## 4. **Connecting Copilots With Actions**
 
 1. Before you can use your action in a copilot you need to publish your action. In the action page, in the top left, click Actions -> Publish Action
 
 ![copilot_action_publish](/docs/assets/actions/action-publish.png)
 
-
 2. A copilot can have any number of actions it's connected to, to connect an action to a copilot go to the copilots page
 
-3. Select the copilot you'd like to connect an action to 
+3. Select the copilot you'd like to connect an action to
 
 ![copilots_table](/docs/assets/copilots/copilot-collaboration/copilots-table.png)
 

--- a/fern/docs/pages/guides/actions/copilot-collaboration.mdx
+++ b/fern/docs/pages/guides/actions/copilot-collaboration.mdx
@@ -1,4 +1,4 @@
-_This is a comprehensive guide for Copilots calling. If you’re just getting started, check out [Getting Started With AI Copilots](/copilots/quick-start)._
+_This is a comprehensive guide for Copilots calling. If you’re just getting started, check out [Getting Started With AI Copilots](/getting-started/copilots/quick-start)._
 
 Copilots allow users to create dedicated assistants that can be honed in on specific use cases and tasks. With copilots calling copilots you can open up the space for more complex queries and responses.
 
@@ -42,7 +42,7 @@ Now that you have some discoverable copilots, you can connect other copilots to 
 
 ## 3. **Approving Connection Requests**
 
-Once people discover your copilot and request to consult it you'll have a list of pending approvals, here's how to manage them: 
+Once people discover your copilot and request to consult it you'll have a list of pending approvals, here's how to manage them:
 
 1. On your discoverable copilot go to the Deploy Tab to see all pending approvals
 
@@ -54,13 +54,12 @@ Once people discover your copilot and request to consult it you'll have a list o
 
 ## 4. **Using One Copilot to Call Another**
 
-After the connection handshake has occurred you are now able to call that copilot from your own. 
+After the connection handshake has occurred you are now able to call that copilot from your own.
 
-Requests will automatically be routed to the available copilot based on the exact instructions and documentation given to your orchestrator as well as the descriptions of the callee Copilots.  
+Requests will automatically be routed to the available copilot based on the exact instructions and documentation given to your orchestrator as well as the descriptions of the callee Copilots.
 
 **Note:** Copilots calling other copilots will only reach a max depth of 3 calls.
 
 ## 5. Contact Support
 
 For questions or support, contact support@credal.ai.
-

--- a/fern/docs/pages/guides/copilots/in-depth-guide.mdx
+++ b/fern/docs/pages/guides/copilots/in-depth-guide.mdx
@@ -1,4 +1,4 @@
-_This is a comprehensive in depth guide for Copilots. If you’re just getting started, check out [Getting Started With AI Copilots](/copilots/quick-start)._
+_This is a comprehensive in depth guide for Copilots. If you’re just getting started, check out [Getting Started With AI Copilots](/getting-started/copilots/quick-start)._
 
 Credal’s AI Copilots empower users to set up dedicated assistants for a wide range of use cases, from customer support to contract review.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix broken links to 'Getting Started With AI Copilots' in three markdown files by updating the path.
> 
>   - **Links**:
>     - Fix broken link to 'Getting Started With AI Copilots' in `actions.mdx`, `copilot-collaboration.mdx`, and `in-depth-guide.mdx` by updating path to `/getting-started/copilots/quick-start`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for cdad8d3e092be89d93c6bc1121a2c8da31375ff6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->