### PR TITLE
Replace Use Cases card with Quickstart

### DIFF
--- a/fern/docs/pages/guides/overview.mdx
+++ b/fern/docs/pages/guides/overview.mdx
@@ -5,9 +5,9 @@ subtitle: Welcome to Credal's documentation! Here you'll find information to get
 
 <CardGroup cols={2}>
   <Card
-    title="Use Cases"
-    icon="fa-solid fa-head-side-brain"
-    href="https://www.credal.ai/use-cases"
+    title="Quickstart"
+    icon="fa-solid fa-bolt"
+    href="https://credalai.notion.site/Credal-Quickstart-Guide-9f1d589bc51a461e9c9860c2180abc58"
   />
   <Card title="API Reference" icon="fa-solid fa-code" href="/api-reference" />
   <Card title="Blog" icon="fa-solid fa-signal" href="https://credal.ai/blog" />


### PR DESCRIPTION
Deprecate link to old Use Cases page, so we stop getting spammed with requests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace "Use Cases" card with "Quickstart" card in `overview.mdx`, updating icon and link.
> 
>   - **Documentation Update**:
>     - In `overview.mdx`, replace "Use Cases" card with "Quickstart" card.
>     - Update card icon to `fa-solid fa-bolt`.
>     - Change card link to `https://credalai.notion.site/Credal-Quickstart-Guide-9f1d589bc51a461e9c9860c2180abc58`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for 0358a1e1a0625e2ae7a531a2ec23859f04349be8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->