### PR TITLE
Add error chunk to stream message api definition

### DIFF
--- a/fern/definition/copilots.yml
+++ b/fern/definition/copilots.yml
@@ -328,6 +328,50 @@ service:
                   policyTriggers: []
                   warnings: []
                   blocks: ["This request contains PII"]
+        - name: Example Error
+          request:
+            copilotId: 82e4b12a-6990-45d4-8ebd-85c00e030c25
+            message: Is Credal SOC 2 compliant?
+            email: ravin@credal.ai
+            inputVariables:
+              [
+                { name: "input1", ids: [82e4b12a-6990-45d4-8ebd-85c00e030c24] },
+                {
+                  name: "input2",
+                  ids:
+                    [
+                      82e4b12a-6990-45d4-8ebd-85c00e030c25,
+                      82e4b12a-6990-45d4-8ebd-85c00e030c26,
+                    ],
+                },
+              ]
+          response:
+            stream:
+              - event: initial
+                data:
+                  event: initial
+                  conversationId: fc938005-92db-411a-88eb-32ca50d5f744
+                  webSearchResults:
+                    [
+                      {
+                        title: "SOC 2 Compliance",
+                        url: "https://www.credal.ai/soc2",
+                        contents: "Credal is SOC 2 compliant. Learn more about SOC 2 compliance at Credal.",
+                      },
+                    ]
+                  warnings: []
+              - event: error_chunk
+                data:
+                  event: error_chunk
+                  error:
+                    message: This is an error
+              - event: end_of_message
+                data:
+                  event: end_of_message
+              - event: final_chunk
+                data:
+                  event: final_chunk
+                  sources: []
 
     addCollectionToCopilot:
       availability: pre-release
@@ -590,7 +634,7 @@ types:
   FinalChunk:
     properties:
       sources: list<ReferencedSource>
-  
+
   EndOfMessageChunk:
     properties: {}
 
@@ -601,6 +645,14 @@ types:
       blocks: list<string>
       policyTriggers: list<PolicyTrigger>
 
+  ErrorChunkData:
+    properties:
+      message: string
+
+  ErrorChunk:
+    properties:
+      error: ErrorChunkData
+
   StreamingChunk:
     discriminant: event
     union:
@@ -609,3 +661,4 @@ types:
       end_of_message: EndOfMessageChunk
       final_chunk: FinalChunk
       blocked: BlockedChunk
+      error_chunk: ErrorChunk


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `error_chunk` event to `streamMessage` API in `copilots.yml` for error handling in streamed responses.
> 
>   - **Behavior**:
>     - Adds `error_chunk` event to `streamMessage` API in `copilots.yml` to handle errors in streamed responses.
>     - New example `Example Error` added to demonstrate error handling in `streamMessage`.
>   - **Types**:
>     - Defines `ErrorChunkData` and `ErrorChunk` types in `copilots.yml`.
>     - Updates `StreamingChunk` union to include `error_chunk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for 99fc4a4cee3a0f959e7f798f28d9089d7f39fde0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->