### PR TITLE
chore: bump ts generator

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,7 +3,7 @@ groups:
   typescript-sdk:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.41.1
+        version: 0.49.4
         output:
           location: npm
           package-name: "@credal/sdk"


### PR DESCRIPTION
This PR upgrades your TypeScript generator. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps TypeScript generator version from `0.41.1` to `0.49.4` in `fern/generators.yml`.
> 
>   - **Version Update**:
>     - Bumps TypeScript generator version from `0.41.1` to `0.49.4` in `fern/generators.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for c4ba5f39bf7c432557347af69c9ceb0e391c91f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->