### PR TITLE
Add salesforce docs to navbar

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -100,6 +100,8 @@ navigation:
               path: ./docs/pages/guides/building-agents/snowflake-query/query-approaches.mdx
             - page: Testing your solution
               path: ./docs/pages/guides/building-agents/snowflake-query/testing-solution.mdx
+          - page: Salesforce Query Assistant
+            path: ./docs/pages/guides/building-agents/salesforce-example.mdx
       - page: Bulk Analysis
         path: ./docs/pages/guides/bulk-analysis.mdx
       - page: Permissions Service


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Salesforce Query Assistant` page to documentation navigation in `docs.yml`.
> 
>   - **Documentation**:
>     - Adds `Salesforce Query Assistant` page to the navigation in `docs.yml`, linking to `./docs/pages/guides/building-agents/salesforce-example.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for 51640dc83d2d2e0e957549e15dc8a2a8b17a00bf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->