### PR TITLE
Repoint notion links to fern

### DIFF
--- a/fern/docs/pages/guides/agents/quick-start.mdx
+++ b/fern/docs/pages/guides/agents/quick-start.mdx
@@ -33,7 +33,7 @@ You can click on “Agents” in your left sidebar anytime to view the full list
 
 ### Configure the Agent
 
-Now your agent is set up, Credal will automatically direct you to the configure page, where you can tune your agent for your use case. You can return to this page to edit your settings at any time. (For a detailed explanation of all the options, please see our [Detailed Agents User Guide](https://www.notion.so/AI-Copilots-In-Depth-Guide-73e09c563d9246cca5241890efef5de4?pvs=21).)
+Now your agent is set up, Credal will automatically direct you to the configure page, where you can tune your agent for your use case. You can return to this page to edit your settings at any time. (For a detailed explanation of all the options, please see our [Detailed Agents User Guide](https://docs.credal.ai/getting-started/agents/in-depth-guide).)
 
 1. Your **Metadata** (Name + Description) will be set already.
 2. You can use the default **Model** (GPT-4o) for now, but feel free to experiment with OpenAI o1, Claude or any of the other models too.
@@ -134,6 +134,6 @@ If more than one agent is deployed to a given Slack channel, Credal will triage 
 
    </Steps>
 
-That's all! The [detailed guide](https://www.notion.so/AI-Copilots-In-Depth-Guide-73e09c563d9246cca5241890efef5de4?pvs=21) contains more information, including on deploying this to non-Slack applications, and a more detailed explanation of the options in Copilots.
+That's all! The [detailed guide](https://docs.credal.ai/getting-started/agents/in-depth-guide) contains more information, including on deploying this to non-Slack applications, and a more detailed explanation of the options in Copilots.
 
 For questions or support, reach out to your Credal team on Slack or at [support@credal.ai](mailto:support@credal.ai).

--- a/fern/docs/pages/guides/bulk-analysis-in-depth-guide.mdx
+++ b/fern/docs/pages/guides/bulk-analysis-in-depth-guide.mdx
@@ -1,6 +1,6 @@
 # Bulk Analysis In-Depth Guide
 
-_This is a 20 minute guide to setting up and running a Bulk Analysis in Credal. Prerequisites are that you have read the [AI Copilots User guide](https://www.notion.so/AI-Copilots-In-Depth-Guide-73e09c563d9246cca5241890efef5de4?pvs=21)._
+_This is a 20 minute guide to setting up and running a Bulk Analysis in Credal. Prerequisites are that you have read the [AI Copilots User guide](https://docs.credal.ai/getting-started/agents/in-depth-guide)._
 
 Bulk Analysis is a powerful tool that you can use to **streamline** operations for greater speed, quality, and detail. If you have a massive amount of data you want to deeply understand, this Credal feature will help you accomplish that by extracting the details you care about.
 

--- a/fern/docs/pages/guides/bulk-analysis.mdx
+++ b/fern/docs/pages/guides/bulk-analysis.mdx
@@ -4,7 +4,7 @@ Credal’s Bulk Analysis feature allows users to analyze a collection of documen
 
 ## In Depth Guide
 
-_This is a 20 minute guide to setting up and running a Bulk Analysis in Credal. Prerequisites are that you have read the [AI Agents User guide](https://www.notion.so/AI-Copilots-In-Depth-Guide-73e09c563d9246cca5241890efef5de4?pvs=21)._
+_This is a 20 minute guide to setting up and running a Bulk Analysis in Credal. Prerequisites are that you have read the [AI Agents User guide](https://docs.credal.ai/getting-started/agents/in-depth-guide)._
 
 Bulk Analysis is a powerful tool that you can use to **accelerate** analyses of a large number of documents, transcripts, or spreadsheets using LLMs. If you have a large amount of documents or data and you want to be able to classify each, extract key fields, or in any other way ask the same questions across each of the documents, this Credal feature will help you accomplish that by parallelizing your LLM requests for each document.
 


### PR DESCRIPTION
These notion links should point to the fern version (identical content).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Notion links to Fern links in `quick-start.mdx` for documentation references.
> 
>   - **Documentation**:
>     - Update Notion links to Fern links in `quick-start.mdx` for the "Detailed Agents User Guide" and the "detailed guide" references.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for c32217dcb94920203aae4f8b0eeed69cbde3b6d9. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->