### PR TITLE
Data sources page -> data integrations page 

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -82,24 +82,24 @@ navigation:
             path: ./docs/pages/guides/building-agents/overview.mdx
           - section: Employee Onboarding Assistant
             contents:
-            - page: Overview
-              path: ./docs/pages/guides/building-agents/employee-onboarding/overview.mdx
-            - page: Answer Basic Questions
-              path: ./docs/pages/guides/building-agents/employee-onboarding/version-1.mdx
-            - page: Searching Internal and External Knowledge
-              path: ./docs/pages/guides/building-agents/employee-onboarding/version-2.mdx
-            - page: Connect with Internal Systems 
-              path: ./docs/pages/guides/building-agents/employee-onboarding/version-3.mdx
+              - page: Overview
+                path: ./docs/pages/guides/building-agents/employee-onboarding/overview.mdx
+              - page: Answer Basic Questions
+                path: ./docs/pages/guides/building-agents/employee-onboarding/version-1.mdx
+              - page: Searching Internal and External Knowledge
+                path: ./docs/pages/guides/building-agents/employee-onboarding/version-2.mdx
+              - page: Connect with Internal Systems
+                path: ./docs/pages/guides/building-agents/employee-onboarding/version-3.mdx
           - section: Snowflake Query Assistant
             contents:
-            - page: Overview
-              path: ./docs/pages/guides/building-agents/snowflake-query/overview.mdx
-            - page: Initial Snowflake Setup
-              path: ./docs/pages/guides/building-agents/snowflake-query/initial-setup.mdx
-            - page: Query Approaches
-              path: ./docs/pages/guides/building-agents/snowflake-query/query-approaches.mdx
-            - page: Testing your solution
-              path: ./docs/pages/guides/building-agents/snowflake-query/testing-solution.mdx
+              - page: Overview
+                path: ./docs/pages/guides/building-agents/snowflake-query/overview.mdx
+              - page: Initial Snowflake Setup
+                path: ./docs/pages/guides/building-agents/snowflake-query/initial-setup.mdx
+              - page: Query Approaches
+                path: ./docs/pages/guides/building-agents/snowflake-query/query-approaches.mdx
+              - page: Testing your solution
+                path: ./docs/pages/guides/building-agents/snowflake-query/testing-solution.mdx
           - page: Salesforce Query Assistant
             path: ./docs/pages/guides/building-agents/salesforce-example.mdx
       - page: Bulk Analysis
@@ -108,7 +108,7 @@ navigation:
         path: ./docs/pages/guides/permissions-service.mdx
       - page: Prompting
         path: ./docs/pages/guides/prompting.mdx
-      - page: Data Sources
+      - page: Data Integrations
         path: ./docs/pages/guides/data-sources.mdx
   - api: API Reference
     snippets:
@@ -141,4 +141,3 @@ logo:
   height: 30
 
 css: ./styles.css
-


### PR DESCRIPTION
Ignore the yaml formatting that my vscode did thats just noise
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames 'Data Sources' to 'Data Integrations' in the documentation navigation.
> 
>   - **Navigation Update**:
>     - Renames 'Data Sources' to 'Data Integrations' in `fern/docs.yml` under the navigation section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for a3ab7bf3a93735b879daec2667e3afdcd2f35e94. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->