### PR TITLE
Redirect old data integrations page to new one

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -141,3 +141,7 @@ logo:
   height: 30
 
 css: ./styles.css
+
+redirects:
+  - source: /getting-started/data-integrations
+    destination: /getting-started/data-sources-action-providers


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add redirect in `docs.yml` from `/getting-started/data-integrations` to `/getting-started/data-sources-action-providers`.
> 
>   - **Redirects**:
>     - Added redirect in `docs.yml` from `/getting-started/data-integrations` to `/getting-started/data-sources-action-providers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Credal-ai%2Ffern-docs&utm_source=github&utm_medium=referral)<sup> for 650892a8c528a2ba24c55e9716ad9b74af51cb80. You can [customize](https://app.ellipsis.dev/Credal-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->