### PR TITLE
Update action-security-model

### DIFF
--- a/fern/docs/pages/guides/actions/action-security-model.mdx
+++ b/fern/docs/pages/guides/actions/action-security-model.mdx
@@ -18,8 +18,8 @@ No users can execute outside the scope of the credentials and permissions that a
 | Non exhaustive Source examples | Salesforce / Credal enterprise search / Jamf / Kanji | Slack / MongoDB / Gong | Looker / Snowflake / (Formerly Kanji & Jamf) | Webhook |
 | Where is resource level access handled? | In the provider’s implementation | In Credal’s implementation of interfacing with provider API | ²Trusted allowlist defined in action | ²Trusted allowlist defined in action |
 | Create the connection? | Anyone | Admin | Admin | Anyone |
-| Create an Action? | Anyone | Anyone | Admin | Anyone |
-| Edit the Action? | Action Collaborator | Action Collaborator | Admin, until we have version control for Actions³ | Admin, until we have version control for Actions³ |
+| Create an Action? | Anyone | Anyone | Admin | Admin, until we have version control for Actions³ |
+| View configuration details / Edit the Action? | Action Collaborator | Action Collaborator | Admin, until we have version control for Actions³ | Admin, until we have version control for Actions³ |
 | Publish the Action to the whole organization? | Action Collaborator | Action Collaborator | Admin | Admin |
 | Publish the Action to Select Users/Groups? | Action Collaborator | Action Collaborator | Admin | Admin |
 | Publish the Action to All Agents in Organization | Admin, Not for security purposes | Admin, Not for security purposes | Admin | Admin |


### PR DESCRIPTION
Update the security model to match the table here: https://docs.google.com/document/d/1xwRd29OD0-fcHiAvWVrtc9PuMRUlB8n-PFU1zhwSWyw/edit?tab=t.0

Changes:
- make creating a webhook action admin-only (for now). this is because we expect that it's confusing for a user to be able to create but not edit an action.
- make permissions for viewing action details the same as those for editing the action

See more context: https://credalai.slack.com/archives/C08G0NU6872/p1749136157598129?thread_ts=1749071729.387809&cid=C08G0NU6872