### PR TITLE
Add optional field `jsonObject` to `ResponseChunk`

### DIFF
--- a/fern/definition/copilots.yml
+++ b/fern/definition/copilots.yml
@@ -526,7 +526,7 @@ types:
     properties:
       message: string
       dataChunk: string
-      jsonObject: optional<unknown>
+      structuredOutput: optional<unknown>
 
   InsertedAuditLog:
     properties:

--- a/fern/definition/copilots.yml
+++ b/fern/definition/copilots.yml
@@ -526,6 +526,7 @@ types:
     properties:
       message: string
       dataChunk: string
+      jsonObject: optional<unknown>
 
   InsertedAuditLog:
     properties:


### PR DESCRIPTION
This is intended to output the `message` as a JSON object, iff it is using structured outputs / JSON mode