### PR TITLE
Add back actions.yml

### DIFF
--- a/fern/definition/actions.yml
+++ b/fern/definition/actions.yml
@@ -1,0 +1,32 @@
+imports:
+  common: ./common.yml
+
+types:
+  HumanConfirmationChannel:
+    union:
+      directMessage: DirectMessage
+      slackThread: SlackThread
+      conversation: Conversation
+  DirectMessage:
+    properties:
+      channelId: string
+  SlackThread:
+    properties:
+      channelId: string
+      threadTimestamp: string
+  Conversation:
+    properties:
+      conversationId: uuid
+  InvokeActionResponse:
+    properties:
+      actionInvocationId: uuid
+      actionInvocationStatus: ActionStatus
+  ActionStatus:
+    enum:
+      - PENDING_APPROVAL
+      - APPROVED_IN_PROGRESS
+      - NO_APPROVAL_NEEDED_IN_PROGRESS
+      - APPROVED_SUCCEEDED
+      - APPROVED_FAILED
+      - NO_APPROVAL_NEEDED_SUCCEEDED
+      - NO_APPROVAL_NEEDED_FAILED


### PR DESCRIPTION
This file was deleted in https://github.com/Credal-ai/fern-docs/pull/149

However our `app` repo still depends on the types generated downstream of this, imported from `@credal/sdk`

Therefore we cant update the `@credal/sdk` version without having these types here