### PR TITLE
More precise types for `customMetadata` fields

### DIFF
--- a/fern/definition/common.yml
+++ b/fern/definition/common.yml
@@ -58,3 +58,10 @@ types:
         value: "=="
       - name: CONTAINS
         value: "contains"
+  CustomMetadataValue:
+    discriminated: false
+    union:
+      - string
+      - integer
+      - boolean
+      - date

--- a/fern/definition/documentCatalog.yml
+++ b/fern/definition/documentCatalog.yml
@@ -36,7 +36,7 @@ service:
               docs: |
                 The external URL of the document you want to upload. If provided Credal will link to this URL.
             customMetadata:
-              type: optional<map<string, unknown>>
+              type: optional<map<string, common.CustomMetadataValue>>
               docs: |
                 Optional JSON representing any custom metadata for this document
             collectionId:


### PR DESCRIPTION
Types that we accept now:

```
...
customMetadata: z.record(z.union([z.string(), z.number(), z.boolean()]).nullish()).nullish(),
...
```

Tested using `fern docs dev`

<img width="578" height="332" alt="Screenshot 2025-08-18 at 12 13 15 PM" src="https://github.com/user-attachments/assets/8ef07db4-3fae-43f3-85d1-c52a57ab3a8f" />

