### PR TITLE
overview page for api v1

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -8,6 +8,7 @@
     "Automations",
     "Balli",
     "productionizing",
+    "PKCE",
     "API",
     "APIs",
     "Credal",

--- a/fern/apis/v0/docs/docs.yml
+++ b/fern/apis/v0/docs/docs.yml
@@ -1,4 +1,7 @@
 navigation:
+  - page: Overview
+    slug: overview
+    path: ./overview.mdx
   - api: API Reference
     api-name: v0
     snippets:

--- a/fern/apis/v0/docs/overview.mdx
+++ b/fern/apis/v0/docs/overview.mdx
@@ -1,7 +1,12 @@
 ## Overview
 
-The Credal API v0 provides a simple interface for sending messages to agents using static API keys.
+The Credal API v0 provides a simple interface for sending messages to simple
+agents using static API keys. Agents called via API v0 cannot access any actions
+that require authentication. API v0 is considered legacy.
 
 <Note>
-API v1 is now available in beta with support for asynchronous agent messaging, [actions](/user-guide/platform/governed-actions/overview), and OAuth 2.0 authentication. [Check out the v1 docs](/api-reference/v-1/overview) to learn more.
+API v1 is now available in beta with support for asynchronous agent messaging,
+[actions](/user-guide/platform/governed-actions/overview), and OAuth 2.0
+authentication. API v1 is also more performant and can handle higher scale
+traffic. [Check out the v1 docs](/api-reference/v-1/overview) to learn more.
 </Note>

--- a/fern/apis/v0/docs/overview.mdx
+++ b/fern/apis/v0/docs/overview.mdx
@@ -1,0 +1,7 @@
+## Overview
+
+The Credal API v0 provides a simple interface for sending messages to agents using static API keys.
+
+<Note>
+API v1 is now available in beta with support for asynchronous agent messaging, [actions](/user-guide/platform/governed-actions/overview), and OAuth 2.0 authentication. [Check out the v1 docs](/api-reference/v-1/overview) to learn more.
+</Note>

--- a/fern/apis/v1/docs/docs.yml
+++ b/fern/apis/v1/docs/docs.yml
@@ -1,4 +1,9 @@
 navigation:
+  - page: Overview
+    slug: overview
+    path: ./overview.mdx
+  - page: OAuth Setup
+    path: ./oauth-setup.mdx
   - api: API Reference
     api-name: v1
     snippets:

--- a/fern/apis/v1/docs/oauth-setup.mdx
+++ b/fern/apis/v1/docs/oauth-setup.mdx
@@ -1,0 +1,47 @@
+## OAuth Setup
+
+API v1 uses OAuth 2.0 with PKCE for authentication. If you're new to OAuth, see [OAuth 2.0 with PKCE](https://oauth.net/2/pkce/) for background on the protocol.
+
+### 1. Register an OAuth client
+
+Creating an OAuth client requires approval from your organization's admin. To request one, ask your admin to contact [support@credal.ai](mailto:support@credal.ai).
+
+### 2. Configure your environment
+
+After registering your client, you'll have a **client ID** and **client secret**. Configure your OAuth client with the following:
+
+| Parameter | Value |
+|---|---|
+| Issuer / Discovery URL | `https://app.credal.ai` |
+| Redirect URI | Your app's callback URL (e.g. `http://localhost:4000/callback`) |
+
+Credal supports [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html), so most OAuth libraries can auto-configure endpoints from the issuer URL.
+
+When requesting authorization, include the scopes your application needs. The following scopes are available:
+
+| Scope | Description |
+|---|---|
+| `api:agent:message:*` | Send messages to agents and fetch responses |
+
+### 3. Authenticate and call the API
+
+After completing the OAuth flow, pass the access token to the Credal SDK:
+
+```typescript
+import { CredalClient } from "@credal/sdk";
+
+const credal = new CredalClient({
+  token: accessToken,
+  environment: "https://app.credal.ai/api/v1",
+});
+
+const response = await credal.agents.sendMessage({
+  agentId: "your-agent-id",
+  conversation: { type: "new" },
+  message: "Hello!",
+});
+```
+
+### Token refresh
+
+Access tokens are short-lived. Use the refresh token from the initial authorization to obtain new access tokens when they expire. Refer to your OAuth library's documentation for details on implementing token refresh.

--- a/fern/apis/v1/docs/overview.mdx
+++ b/fern/apis/v1/docs/overview.mdx
@@ -10,7 +10,7 @@ API v1 brings fully featured agent messaging to the Credal API. Your application
 
 **Improved reliability** — v1 is built on Credal's new agent messaging system with greater investment in resilience and error handling, providing more robust delivery and clearer failure modes compared to v0.
 
-**OAuth 2.0 authentication** — instead of a static API key scoped to a single agent, v1 uses OAuth. After a user completes the [OAuth flow](./oauth-setup.mdx), your app can message any agent that user has access to.
+**OAuth 2.0 authentication** — instead of a static API key scoped to a single agent, v1 uses OAuth. After a user completes the [OAuth flow](/api-reference/v-1/oauth-setup), your app can message any agent that user has access to.
 
 ### What changed from v0
 
@@ -28,6 +28,6 @@ API v1 is in active development. New endpoints and capabilities will be added on
 
 ### Getting started
 
-1. **Register an OAuth client** — set up your application as an OAuth client in Credal.
-2. **Implement the OAuth flow** — redirect users to Credal's authorization endpoint, then exchange the authorization code for an access token.
+1. **Register an OAuth client** — set up your application as an OAuth client in Credal. See [OAuth Setup](/api-reference/v-1/oauth-setup) for instructions.
+2. **Implement the OAuth flow** — redirect users to Credal's authorization endpoint, then exchange the authorization code for an access token. Refer to the [OAuth Setup](/api-reference/v-1/oauth-setup) guide for details.
 3. **Call the API** — use the access token as a Bearer token in API requests.

--- a/fern/apis/v1/docs/overview.mdx
+++ b/fern/apis/v1/docs/overview.mdx
@@ -1,0 +1,33 @@
+## Overview
+
+API v1 brings fully featured agent messaging to the Credal API. Your application can now interact with agents that use [actions](/user-guide/platform/governed-actions/overview) — the same rich agent experience available in the Credal UI, now accessible programmatically.
+
+### What's new in v1
+
+**Full agent messaging with [actions](/user-guide/platform/governed-actions/overview)** — v0 only supported simple text-in, text-out interactions. v1 supports the complete agent loop, including agents that use actions to search documents, query databases, create tickets, and more.
+
+**Asynchronous messaging** — v0 was synchronous: you sent a message and blocked until the response came back. v1 uses a fire-and-poll pattern — `sendMessage` returns a `jobId`, and you poll `fetchAgentResponse` until the result is ready. This supports longer-running agent interactions involving actions. Note that responses are ephemeral and should be fetched promptly rather than relied on to be available indefinitely.
+
+**Improved reliability** — v1 is built on Credal's new agent messaging system with greater investment in resilience and error handling, providing more robust delivery and clearer failure modes compared to v0.
+
+**OAuth 2.0 authentication** — instead of a static API key scoped to a single agent, v1 uses OAuth. After a user completes the [OAuth flow](./oauth-setup.mdx), your app can message any agent that user has access to.
+
+### What changed from v0
+
+| | v0 | v1 |
+|---|---|---|
+| **Agent messaging** | Synchronous, text-only | Async fire-and-poll with [actions](/user-guide/platform/governed-actions/overview) |
+| **Auth method** | Static API key | OAuth 2.0 |
+| **Scope** | Single agent | All agents the user can access |
+| **Token lifetime** | Long-lived | Short-lived (refresh via OAuth) |
+| **User context** | None | Requests run as the authenticated user |
+
+<Note>
+API v1 is in active development. New endpoints and capabilities will be added on an ongoing basis.
+</Note>
+
+### Getting started
+
+1. **Register an OAuth client** — set up your application as an OAuth client in Credal.
+2. **Implement the OAuth flow** — redirect users to Credal's authorization endpoint, then exchange the authorization code for an access token.
+3. **Call the API** — use the access token as a Bearer token in API requests.


### PR DESCRIPTION
Thicc explainer on what API v1 is. Super open to suggestions on the copy here.
Goals are for developers to move over to API v1 for agent messaging as soon as possible so we can kill old SAM!

https://credal-preview-1b236912-5948-4917-922e-d1f3b4a4f552.docs.buildwithfern.com/api-reference/v-1/overview

https://credal-preview-1b236912-5948-4917-922e-d1f3b4a4f552.docs.buildwithfern.com/api-reference/v-1/o-auth-setup