### PR TITLE
slightly more specific wording about v0 agent messaging being considered legacy

### DIFF
--- a/fern/apis/v0/docs/overview.mdx
+++ b/fern/apis/v0/docs/overview.mdx
@@ -2,7 +2,7 @@
 
 The Credal API v0 provides a simple interface for sending messages to simple
 agents using static API keys. Agents called via API v0 cannot access any actions
-that require authentication. API v0 is considered legacy.
+that require authentication. Sending agent messages via API v0 is considered legacy.
 
 <Note>
 API v1 is now available in beta with support for asynchronous agent messaging,


### PR DESCRIPTION
The non-agent-messaging aspects of API v0 are fine, and it's not a problem for SAM cleanup if apps continue to use those.