### PR TITLE
docs: document special prompt keywords ({{data}}, {{user_metadata}})

### DIFF
--- a/fern/docs/pages/platform/agents/configure-steps/prompt.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/prompt.mdx
@@ -16,6 +16,28 @@ You can revise this prompt to include the background information and instruction
 
 The content and depth of prompts will vary by use case.
 
+## Special Keywords (Prompt Variables)
+
+Within a custom prompt, you can use special keywords (sometimes called prompt variables or entities) that Credal automatically replaces with dynamic content when generating a response. Wrap each keyword in double curly braces, for example `{{data}}`.
+
+| Keyword | Description |
+| --- | --- |
+| `{{data}}` | Indicates where the context pulled from your attached sources (configured in the [Data](/user-guide/platform/agent-builder/configuration/add-connectors/data) section) should be inserted into the prompt. If you do not include this keyword, Credal will insert the data after your custom prompt. |
+| `{{user_metadata}}` | Indicates where any end-user metadata should be inserted into the prompt. Use this to personalize responses for the user based on context such as location, department, or job role. |
+
+For example, you can place the keywords exactly where you want the corresponding content to appear:
+
+```
+Role: You are a helpful IT assistant.
+
+Personalize your response using the following end-user details.
+User metadata: {{user_metadata}}
+
+--- Start Context ---
+{{data}}
+--- End Context ---
+```
+
 <AccordionGroup>
   <Accordion title="Example Prompt: Federal Rules of Court Agent">
 *You are a diligent, objective, detail-oriented, assistant. Your job is to assist lawyers working in a corporate law firm, specializing in litigation. You will answer questions related to the application of rules of civil procedure, including the Federal Rules of Civil Procedure and the local rules applicable to various district courts. You will respond to questions and prompts truthfully.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sophisticated users have been guessing at which entities (special keywords / prompt variables) can be used within custom prompts. The information from the in-app **Custom Prompt** modal was not present in Credal documentation. This PR copies that information into the docs so it is discoverable via search.

### Changes
- Added a new **Special Keywords (Prompt Variables)** section to the "Writing Instructions" page (`fern/docs/pages/platform/agents/configure-steps/prompt.mdx`).
- The section documents the two entities surfaced in the Custom Prompt modal:
  - `{{data}}` — where context pulled from attached sources is inserted; if omitted, Credal inserts data after the custom prompt.
  - `{{user_metadata}}` — where end-user metadata is inserted, for personalization by location, department, or job role.
- Includes a short example showing where to place each keyword in a prompt.

### Acceptance criteria
- [x] Within Credal documentation, there is a list of entities that can be used within prompts.
- [x] This information is discoverable via search (lives in the indexed "Writing Instructions" docs page with a dedicated, keyword-rich heading).

## Testing
- `cspell --config .cspell.json` on the modified file — 0 issues.
- `fern check` — 0 errors (only pre-existing, unrelated warnings for auth/color contrast).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-493942ad-5d1b-47fb-aeb5-7c0d9bed6271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-493942ad-5d1b-47fb-aeb5-7c0d9bed6271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

