### PR TITLE
Make Fern VPAT compliant

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -35,7 +35,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        # Pinned to v2.8.0: v2.9.0 installs lychee into $RUNNER_TEMP/lychee/bin,
+        # which doesn't propagate to PATH on Blacksmith runners, causing
+        # "lychee: command not found" (exit 127).
+        uses: lycheeverse/lychee-action@v2.8.0
         with:
           # Only scan .mdx and .yml files — no .md or .yaml files exist in this
           # tree, so including those globs just produces noisy "no files found"

--- a/fern/apis/v0/docs/overview.mdx
+++ b/fern/apis/v0/docs/overview.mdx
@@ -4,7 +4,7 @@ The Credal API v0 provides a simple interface for sending messages to simple
 agents using static API keys. Agents called via API v0 cannot access any actions
 that require authentication. Sending agent messages via API v0 is considered legacy.
 
-<Note>
+<Note title="API v1 available in beta">
 API v1 is now available in beta with support for asynchronous agent messaging,
 [actions](/user-guide/platform/governed-actions/overview), and OAuth 2.0
 authentication. API v1 is also more performant and can handle higher scale

--- a/fern/apis/v1/docs/overview.mdx
+++ b/fern/apis/v1/docs/overview.mdx
@@ -22,7 +22,7 @@ API v1 brings fully featured agent messaging to the Credal API. Your application
 | **Token lifetime** | Long-lived | Short-lived (refresh via OAuth) |
 | **User context** | None | Requests run as the authenticated user |
 
-<Note>
+<Note title="Active development">
 API v1 is in active development. New endpoints and capabilities will be added on an ongoing basis.
 </Note>
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -32,7 +32,8 @@ navbar-links:
     url: https://app.credal.ai/signin
 colors:
   accentPrimary:
-    light: "#228be6"
+    light: "#1971c2"
+    dark: "#228be6"
 favicon: docs/assets/favicon.png
 logo:
   href: https://docs.credal.ai/

--- a/fern/docs/pages/administration/connect-mcp-clients.mdx
+++ b/fern/docs/pages/administration/connect-mcp-clients.mdx
@@ -12,7 +12,7 @@ Apps such as ChatGPT, Claude, Claude Cowork or Cursor, allow administrators to *
 
 <AccordionGroup>
   <Accordion title="ChatGPT">
-    <Callout intent="warning">
+    <Callout intent="warning" title="ChatGPT UI changes frequently">
     ChatGPT is quickly evolving its UI. Reach out to your Credal team for help.
   </Callout>
 
@@ -33,7 +33,7 @@ Servers toggled on for use in ChatGPT should now be available to use.
   </Accordion>
 
   <Accordion title="Claude">
-    <Callout intent="warning">
+    <Callout intent="warning" title="Claude UI changes frequently">
     Claude is quickly evolving its UI. Reach out to your Credal team for help connecting MCPs.
   </Callout>
 

--- a/fern/docs/pages/agent-building.mdx
+++ b/fern/docs/pages/agent-building.mdx
@@ -16,6 +16,7 @@ subtitle: Follow along as we build a fully functioning GTM agent in Credal — f
 >
   <iframe
     src="https://www.loom.com/embed/8531c5782c1943ecb930a501edcca1f2"
+    title="Video: Agent building tutorial walking through creating a GTM agent in Credal"
     frameBorder="0"
     webkitallowfullscreen
     mozallowfullscreen

--- a/fern/docs/pages/concepts/prompt-engineering.mdx
+++ b/fern/docs/pages/concepts/prompt-engineering.mdx
@@ -62,7 +62,7 @@ Create detailed instructions that anticipate potential pitfalls and standard ope
 
 Credal provides prompt snippets directly under the background prompt in the Agent Configuration tab. We recommend using these as a starting point for generating more useful responses, though your specific use case may require additional detail!
 
-![prompt-snippets.png](/docs/assets/prompt-engineering/prompt-snippets.png)
+![Prompt snippets shown beneath the background prompt in the Agent Configuration tab](/docs/assets/prompt-engineering/prompt-snippets.png)
 
 Here’s an example of a fully crafted background prompt…
 
@@ -175,7 +175,7 @@ Encourage concise problem-solving with clear instructions. Instead of asking the
 
 So, you did all the work to craft the perfect prompt for your super specific use-case… only to lose it when you hit send? Think again. If you’re a collaborator on a agent, you can copy-paste your work of art into a Suggested Question in the Agent config. Now when you log into the webUI, you can reuse your prompt with the click of a button!
 
-![prompt-engineering.png](/docs/assets/prompt-engineering/prompt-engineering.png)
+![A saved prompt reused as a Suggested Question in the agent configuration](/docs/assets/prompt-engineering/prompt-engineering.png)
 
 We currently don’t support autocompleting prompts for our Slack integration. For Agents published to Slack, we recommend crafting the background prompt to handle the diverse types of messages sent in the channel of your choice.
 

--- a/fern/docs/pages/platform/actions/custom-names-descriptions.mdx
+++ b/fern/docs/pages/platform/actions/custom-names-descriptions.mdx
@@ -20,7 +20,7 @@ When configuring an action, you can override the default name and description:
 3. Edit the **Name** field to provide a custom, business-friendly name
 4. Update the **Description** field to explain what the action does in terms relevant to your organization
 
-![custom-name-desc.png](/docs/assets/actions/custom-name-desc.png)
+![Action settings with editable custom name and description fields](/docs/assets/actions/custom-name-desc.png)
 
 ## Best Practices
 
@@ -29,7 +29,7 @@ When configuring an action, you can override the default name and description:
 - **Stay Consistent**: Use consistent naming conventions across similar actions
 - **Think About Discovery**: Consider how users will search for this action when naming it
 
-<Note>
+<Note title="Credal-only changes">
 Custom names and descriptions only affect how actions appear within Credal. The underlying integration or MCP server functionality remains unchanged.
 </Note>
 

--- a/fern/docs/pages/platform/actions/monitoring.mdx
+++ b/fern/docs/pages/platform/actions/monitoring.mdx
@@ -2,7 +2,7 @@
 
 Credal provides comprehensive monitoring capabilities to track how actions are being used across your organization. The monitoring dashboard gives you visibility into action invocations, execution patterns, and usage trends.
 
-![monitor-actions.png](/docs/assets/actions/monitor-actions.png)
+![Action monitoring dashboard showing invocations and usage trends](/docs/assets/actions/monitor-actions.png)
 
 ## What You Can Monitor
 

--- a/fern/docs/pages/platform/agents/agent-benchmark.mdx
+++ b/fern/docs/pages/platform/agents/agent-benchmark.mdx
@@ -1,7 +1,7 @@
 The Benchmark tab lets you compare different model configurations side-by-side against the same set of test cases. Instead of manually switching models and re-running evaluations one at a time, you define multiple configuration variants and launch a single benchmark run that executes them all in parallel, producing a unified results view.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/benchmark-configs.png" />
+  <img src="/docs/assets/agents/evaluate/benchmark-configs.png" alt="Benchmark tab with side-by-side configuration cards for comparing model variants" />
 </Frame>
 
 ## Setting Up Configurations
@@ -29,12 +29,12 @@ Click **Run Benchmark** to open the confirmation modal. The modal shows:
 - Whether configs will execute in parallel.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/benchmark-run-modal.png" style={{ maxWidth: "480px" }} />
+  <img src="/docs/assets/agents/evaluate/benchmark-run-modal.png" alt="Run Benchmark confirmation modal listing selected configurations, test cases, and trials" style={{ maxWidth: "480px" }} />
 </Frame>
 
 Confirming the run creates one evaluation run per configuration. Each run executes every test case independently, using the model and settings from its configuration card. Your agent's saved configuration is never modified — the overrides exist only for the duration of the benchmark.
 
-<Note>
+<Note title="Parallel execution">
 Enable **Execute configs in parallel** (on by default) to run all configurations concurrently for faster results.
 </Note>
 

--- a/fern/docs/pages/platform/agents/agent-evaluate.mdx
+++ b/fern/docs/pages/platform/agents/agent-evaluate.mdx
@@ -5,7 +5,7 @@ The Evaluate tab helps you systematically test and measure your agent's performa
 Use the "Add Test Case(s)" button to create test questions. You can optionally provide expected answers for reference, though these are not required for evaluation.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/agent-eval.png" />
+  <img src="/docs/assets/agents/evaluate/agent-eval.png" alt="Evaluate tab showing the Add Test Case(s) button and a list of test questions" />
 </Frame>
 
 ### Generating Test Cases with AI
@@ -13,7 +13,7 @@ Use the "Add Test Case(s)" button to create test questions. You can optionally p
 In addition to manually adding test cases, you can use AI to automatically generate a diverse set of evaluation questions with scoring rubrics. Click the **"Generate Test Cases"** button (marked with a sparkle icon) to open the generation modal.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/generate-test-cases-modal.png" />
+  <img src="/docs/assets/agents/evaluate/generate-test-cases-modal.png" alt="Generate Test Cases modal for AI-generated evaluation questions and rubrics" />
 </Frame>
 
 The generator examines your agent's full configuration — including its system prompt, available actions, connected document sources, and MCP servers — and uses an ensemble of AI models to produce 8–12 high-quality test cases. Each generated test case includes:
@@ -34,7 +34,7 @@ When generating test cases, you can choose which document sources inform the que
 Once generation starts, an ensemble of AI models analyzes your agent's configuration and produces test cases. This may take up to a minute.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/generate-test-cases-loading.png" />
+  <img src="/docs/assets/agents/evaluate/generate-test-cases-loading.png" alt="Loading state while AI models analyze the agent configuration and generate test cases" />
 </Frame>
 
 Once generated, the test cases appear in your Evaluate tab alongside any manually created ones. You can edit the questions and rubrics, or delete any that don't fit your needs.
@@ -42,6 +42,7 @@ Once generated, the test cases appear in your Evaluate tab alongside any manuall
 <div style={{ position: "relative", paddingBottom: "53.23%", height: 0 }}>
   <iframe
     src="https://www.loom.com/embed/05169c6427b646e99c86f5bafdcebafc"
+    title="Video: Generating test cases with AI in the Evaluate tab"
     frameborder="0"
     webkitallowfullscreen
     mozallowfullscreen
@@ -71,6 +72,7 @@ The test cases will appear in your Evaluate tab, ready to be scored in your next
 <div style={{ position: "relative", paddingBottom: "73.51%", height: 0 }}>
   <iframe
     src="https://www.loom.com/embed/36b2e3576d0040949a0270041951b577"
+    title="Video: Creating test cases from Monitor logs"
     frameborder="0"
     webkitallowfullscreen
     mozallowfullscreen
@@ -95,8 +97,8 @@ For each test question, you can define a custom rubric that specifies what makes
 
 <img
   src="https://files.buildwithfern.com/visual-editor-images/docs.credal.ai/2026-01-16T18:33:01.065Z/platform/agents/evaluate/image.png"
-  alt="image"
-  title="image"
+  alt="Rubric editor for a test question with criteria, point values, and scoring guidance"
+  title="Rubric editor for a test question with criteria, point values, and scoring guidance"
   noZoom={false}
 />
 
@@ -105,7 +107,7 @@ For each test question, you can define a custom rubric that specifies what makes
 Click "Generate AI Answers" to test your agent against all questions. The agent will generate responses and automatically score them based on your defined rubrics.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/generate-test-case.png" />
+  <img src="/docs/assets/agents/evaluate/generate-test-case.png" alt="Generate AI Answers button running the agent against all test questions" />
 </Frame>
 
 ### **Tracking Performance**
@@ -127,7 +129,7 @@ Watch a video walking you through how to use the Evaluate tab below:
   width="560"
   height="315"
   src="https://www.youtube.com/embed/NoH4O8Ztv1o?si=Vr7fhjhMXQhruoCZ"
-  title="YouTube video player"
+  title="Video: Walkthrough of using the Evaluate tab to test and score your agent"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerpolicy="strict-origin-when-cross-origin"

--- a/fern/docs/pages/platform/agents/agent-reliability-score.mdx
+++ b/fern/docs/pages/platform/agents/agent-reliability-score.mdx
@@ -5,7 +5,7 @@ ARS is designed to be extensible. As Credal supports new agent architectures and
 ARS scores are computed from the test cases and runs you create in the [Evaluate tab](/user-guide/platform/agent-builder/evaluating-your-agent/overview).
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/ars-evaluate-tab.png" />
+  <img src="/docs/assets/agents/evaluate/ars-evaluate-tab.png" alt="Evaluate tab showing the Agent Reliability Score alongside test case results" />
 </Frame>
 
 ## ARS for RAG Agents
@@ -75,7 +75,7 @@ Beyond the aggregate ARS score, Credal provides a per-test-case breakdown for fo
 After an evaluation run completes, the ARS composite score appears in the Evaluate tab alongside test case results. Click on a run to open the Detailed Score Analysis, which shows the composite score, per-metric breakdown, historical rubric scores, and a score performance trend across past runs.
 
 <Frame>
-  <img src="/docs/assets/agents/evaluate/ars-detailed-score.png" />
+  <img src="/docs/assets/agents/evaluate/ars-detailed-score.png" alt="Detailed Score Analysis with composite ARS score, per-metric breakdown, and score trend" />
 </Frame>
 
 Historical ARS data lets you track how your agent's reliability changes over time as you modify prompts, data sources, or configuration.

--- a/fern/docs/pages/platform/agents/agent-testing.mdx
+++ b/fern/docs/pages/platform/agents/agent-testing.mdx
@@ -4,14 +4,14 @@ You can test your agent through Credal's UI or in third-party applications like 
 
 To test an agent in Credal, select your agent by clicking _Select Agent_ in the chat menu.
 
-![agent-select.png](/docs/assets/agents/create-steps/agent-select.png)
+![Select Agent option in the Credal chat menu](/docs/assets/agents/create-steps/agent-select.png)
 
 This will open a popup where you can select your desired agent.
-![agent-select-from-input.png](/docs/assets/agents/create-steps/agent-select-from-input.png)
+![Popup for choosing which agent to chat with](/docs/assets/agents/create-steps/agent-select-from-input.png)
 
 Then simply type your questions in the search bar. Your agent will return an answer, citing the sources relied upon, which you can click to review.
 
-![agent-select-query.png](/docs/assets/agents/create-steps/agent-select-query.png)
+![Agent answering a question in the chat with clickable source citations](/docs/assets/agents/create-steps/agent-select-query.png)
 
 ## Testing in Slack
 
@@ -64,7 +64,7 @@ To systematically measure and track agent quality over time, see the [Evaluating
 
 If you get an error message that the AI is currently unreachable, there may be a few causes.
 
-![agent-troubleshooting.png](/docs/assets/agents/create-steps/agent-troubleshooting.png)
+![Error message stating the AI is currently unreachable](/docs/assets/agents/create-steps/agent-troubleshooting.png)
 
 1. **Too much context data**: This error can also appear if too much context data is being pulled into each prompt through a combination of pinned data, context, Q&A, and searchable sources. This happens because the data the agent reviews each time is running up against the AI's length limits. Reducing the amount of data that the AI reviews every time can resolve the issue.
    1. Sometimes having too many pinned sources, or pinned sources that are too large, can alone cause this issue as those sources will be read by the AI in their entirety each time a user asks a question. Try moving your pinned sources to searchable sources to resolve the issue.

--- a/fern/docs/pages/platform/agents/agent-troubleshooting.mdx
+++ b/fern/docs/pages/platform/agents/agent-troubleshooting.mdx
@@ -2,7 +2,7 @@
 
 If you get an error message that the AI is currently unreachable, there may be a few causes.
 
-![agent-troubleshooting.png](/docs/assets/agents/create-steps/agent-troubleshooting.png)
+![Error message stating the AI is currently unreachable](/docs/assets/agents/create-steps/agent-troubleshooting.png)
 
 1. **Too much context data**: This error can also appear if too much context data is being pulled into each prompt through a combination of pinned data, context, Q&A, and searchable sources. This happens because the data the agent reviews each time is running up against the AI's length limits. Reducing the amount of data that the AI reviews every time can resolve the issue.
    1. Sometimes having too many pinned sources, or pinned sources that are too large, can alone cause this issue as those sources will be read by the AI in their entirety each time a user asks a question. Try moving your pinned sources to searchable sources to resolve the issue.

--- a/fern/docs/pages/platform/agents/configure-steps/agent-collaboration.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/agent-collaboration.mdx
@@ -58,12 +58,12 @@ Now you'll add subagents that your orchestrator can call. You have two options: 
 If you already have specialized agents set up or another team has made their agent discoverable:
 
 1. In the search bar, look for existing agents by name or description
-   ![agent_connection_via_actions](/docs/assets/copilots/copilot-collaboration/copilot-add-agent.png)
+   ![Subagent search bar for finding existing agents by name or description](/docs/assets/copilots/copilot-collaboration/copilot-add-agent.png)
 
 2. Select the agent(s) you want to connect and click **Add**
 
 3. The subagent will now appear in your orchestrator's subagents list
-   ![agent_actions_tab](/docs/assets/copilots/copilot-collaboration/copilot-actions.png)
+   ![Connected subagent listed in the orchestrator's subagents section](/docs/assets/copilots/copilot-collaboration/copilot-actions.png)
 
 **Note**: If you don't see the agent you're looking for, it may not be discoverable yet. See the "Requesting Access to Use Someone Else's Agent" section below.
 
@@ -131,7 +131,7 @@ If you've built a specialized agent that other teams or orchestrators should be 
 2. Navigate to the **Publish** tab
 
 3. Enable the **Callable** toggle to make your agent discoverable
-   ![agent-collaboration-deploy.png](/docs/assets/agents/agent-collaboration-deploy.png)
+   ![Publish tab with the Callable toggle enabled to make the agent discoverable](/docs/assets/agents/agent-collaboration-deploy.png)
 
 4. Configure who can discover and use your agent:
 

--- a/fern/docs/pages/platform/agents/configure-steps/agent-feedback.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/agent-feedback.mdx
@@ -2,8 +2,8 @@ You may have noticed that users have the option to “👍” or “👎” resp
 
 In the “Configure” tab, you can choose to “fetch examples with positive feedback from historical agent usage” to populate the [model Q&A section](/user-guide/platform/agent-builder/configuration/writing-instructions). Once enabled, your agent will learn from these examples and reference them when answering future, similar questions.
 
-![feedback_based_QA_configuration.png](/docs/assets/copilots/feedback_based_QA_configuration.png)
+![Configure tab option to fetch examples with positive feedback from historical agent usage](/docs/assets/copilots/feedback_based_QA_configuration.png)
 
 If you have [published your agent to Slack](/user-guide/platform/agent-builder/publishing-agents/agents-in-slack), when you “👎” a response, you will have the option to add a suggested answer. Your agent will learn from this answer, enabling it to better respond to future similar queries.
 
-![slack_negative_feedback_suggested_answer.png](/docs/assets/copilots/slack_negative_feedback_suggested_answer.png)
+![Slack prompt to add a suggested answer after giving a thumbs-down on an agent response](/docs/assets/copilots/slack_negative_feedback_suggested_answer.png)

--- a/fern/docs/pages/platform/agents/configure-steps/agent-setup-page.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/agent-setup-page.mdx
@@ -12,11 +12,11 @@ _It's helpful to understand what you want your agent to accomplish from the star
 
 On your left sidebar, select "Agents":
 
-![agent-left-nav](/docs/assets/agents/create-steps/agent-left-nav.png)
+![The Agents option in the left sidebar](/docs/assets/agents/create-steps/agent-left-nav.png)
 
 Then click **“Create New Agent”**:
 
-![after-clicking-agent](/docs/assets/agents/create-steps/after-clicking-agent.png)
+![The Agents page with the Create New Agent button](/docs/assets/agents/create-steps/after-clicking-agent.png)
 
 Give your agent a name and add a description of its function in the pop-out form. When configuring your agent, try to be as detailed as you can with the description, as it helps Credal intelligently route queries to the most relevant Agent when you're creating multi-agent workflows.
 
@@ -28,17 +28,17 @@ The description should cover:
 
 The name and description can be edited at any time from the Agent Configuration page.
 
-![agent-configure-edit-page.png](/docs/assets/agents/create-steps/agent-configure-edit-page.png)
+![Editing the agent name and description on the Agent Configuration page](/docs/assets/agents/create-steps/agent-configure-edit-page.png)
 
 Then select **“Create Agent”**
 
-![agent-creation-popup](/docs/assets/agents/create-steps/agent-creation-popup.png)
+![The agent creation form with name and description fields and the Create Agent button](/docs/assets/agents/create-steps/agent-creation-popup.png)
 
 ## Sharing Your Agent
 
 You can add collaborators to your agent by selecting "Actions" → "Share" button in the top right of your Agent Configuration page. This is useful for when you want one or more team members to be able to help build and maintain your agent.
 
-![agent-share-page.png](/docs/assets/agents/create-steps/agent-share-page.png)
+![The share dialog for adding collaborators to an agent](/docs/assets/agents/create-steps/agent-share-page.png)
 
 ### Owners vs. Collaborators
 

--- a/fern/docs/pages/platform/agents/configure-steps/ai-model.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/ai-model.mdx
@@ -26,7 +26,7 @@ Use the Preview tab to compare responses before publishing. For side-by-side tes
 
 </Callout>
 
-![agent-different-models-dropdown.png](/docs/assets/agents/create-steps/agent-different-models-dropdown.png)
+![The model selection dropdown listing models from OpenAI, Anthropic, Google, and Cerebras](/docs/assets/agents/create-steps/agent-different-models-dropdown.png)
 
 <Callout intent="info" icon="fa-solid fa-rotate" title="Automatic Model Fallback">
 If your selected model is deprecated or unavailable, your agent falls back to the current default model for new agents. Review model selections periodically to avoid surprises.
@@ -44,7 +44,7 @@ Set how creative your agent should be. For most use cases, use "**precise**" or 
 - **Higher creativity** → Better for brainstorming, marketing, and creative writing; more likely to produce unexpected responses.
 - **Higher precision** → Better for analysis, research, and accuracy-sensitive work; more likely to stick to provided context.
 
-![agent-model-creativity.png](/docs/assets/agents/create-steps/agent-model-creativity.png)
+![The creativity setting with precise, balanced, and creative options](/docs/assets/agents/create-steps/agent-model-creativity.png)
 
 ---
 
@@ -60,7 +60,7 @@ Set how creative your agent should be. For most use cases, use "**precise**" or 
 ### Enable
 
 <Frame>
-  <img src="/docs/assets/agents/search-tools/code-interpreter.png" />
+  <img src="/docs/assets/agents/search-tools/code-interpreter.png" alt="The Code Interpreter toggle in the agent settings" />
 </Frame>
 
 ### Example Workflow

--- a/fern/docs/pages/platform/agents/configure-steps/connectors/data.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/connectors/data.mdx
@@ -13,10 +13,10 @@ You’re telling the agent that this source is important for this task, and to l
 Once you scroll down to the connectors section you'll be able to see your data sources.
 
 If none have been attached yet it will look like:
-![no-attached-data-sources.png](/docs/assets/agents/create-steps/no-attached-data-sources.png)
+![The connectors section with no data sources attached yet](/docs/assets/agents/create-steps/no-attached-data-sources.png)
 
 If data sources have already been attached you'll see them listed by connector
-![attached-data-sources.png](/docs/assets/agents/create-steps/attached-data-sources.png)
+![Attached data sources listed by connector](/docs/assets/agents/create-steps/attached-data-sources.png)
 
 **2. Attaching Sources**
 
@@ -24,7 +24,7 @@ You can either select a synced source, sync a URL, or upload your own files.
 
 If you want to attach a [document collection](/user-guide/platform/agent-builder/configuration/add-connectors/document-collections/overview), this will be under select a source.
 
-![copilot_data_sources.png](/docs/assets/copilots/copilot_data_sources.png)
+![Options for attaching data by selecting a synced source, syncing a URL, or uploading files](/docs/assets/copilots/copilot_data_sources.png)
 
 **2. Bookmarking Data**
 
@@ -32,7 +32,7 @@ By bookmarking (or pinning) data sources, you can force your agent to refer to c
 
 To use this feature, click the "pin" button on the source after uploading your data.
 
-![copilot_pin_document.png](/docs/assets/copilots/copilot_pin_document.png)
+![The pin button on an attached data source for bookmarking it](/docs/assets/copilots/copilot_pin_document.png)
 
 **3. Add User Input**
 
@@ -42,7 +42,7 @@ When this option is configured, the agent will prompt users to attach their docu
 
 We strongly recommend leaving the defaults of "Allow multiple documents" and AI reads full inputs", except in very specific circumstances where you are certain that this is not what you want to do.
 
-![copilot_add_user_input.png](/docs/assets/copilots/copilot_add_user_input.png)
+![The Add user input settings for letting users upload their own documents](/docs/assets/copilots/copilot_add_user_input.png)
 
 **4. Tailoring Source Retrieval**
 
@@ -50,7 +50,7 @@ Note: These are advanced settings. The agent comes with defaults that work well 
 
 When the agent answers a question, it looks through your documents and pulls out pieces of text (called “chunks”) to help form a response. You can fine-tune how it does this:
 
-![tailoring_source_retrieval.gif](/docs/assets/copilots/tailoring_source_retrieval.gif)
+![Adjusting the number of chunks and similarity threshold in the advanced retrieval settings](/docs/assets/copilots/tailoring_source_retrieval.gif)
 
 - **Number of chunks:** Think of this as how many pieces of text the agent gathers before answering. If you know your document is in the data provided to your agent, but the agent is not finding it, try expanding the number of chunks. Most agents can safely go up to around 100 chunks without problems. If you find that your agent is finding the right data, but that it is getting confused or distracted by less relevant information, trying cutting the number of chunks down.
 

--- a/fern/docs/pages/platform/agents/configure-steps/connectors/document-collections.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/connectors/document-collections.mdx
@@ -122,7 +122,7 @@ When enabled, the agent queries every document in each selected collection again
 ### How to Enable
 
 <Frame>
-  <img src="/docs/assets/agents/search-tools/deep-summarize.png" alt="Toggle for enabling Deep Summarize on a document collection" />
+  <img src="/docs/assets/agents/search-tools/deep-summarize.png" alt="Collection settings panel with the Enable Deep Summarize Mode toggle turned on" />
 </Frame>
 
 **Best Practices**
@@ -149,7 +149,7 @@ Smart Filtering narrows searches to documents matching specific metadata or enti
 1. Enable Smart Filtering:
 
    <Frame>
-     <img src="/docs/assets/agents/search-tools/deep-summarize.png" alt="Toggle for enabling Smart Filtering on a document collection" />
+     <img src="/docs/assets/agents/search-tools/deep-summarize.png" alt="Collection settings panel with the Enable Smart Filtering toggle" />
    </Frame>
 
 2. Set up your document collection with a [Collection Schema](/user-guide/platform/agent-builder/configuration/add-connectors/document-collections/collection-schemas):

--- a/fern/docs/pages/platform/agents/configure-steps/connectors/document-collections.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/connectors/document-collections.mdx
@@ -10,7 +10,7 @@ Document Collections let you organize your files, documents, and web pages into 
 
 - Navigate to Document Collections from the left sidebar.
   <Frame>
-    <img src="/docs/assets/collections/collections-sidebar.png" />
+    <img src="/docs/assets/collections/collections-sidebar.png" alt="Document Collections option in the left sidebar" />
   </Frame>
 - Click the Create new collection button in the top-right corner.
 - In the dialog that appears, fill in:
@@ -39,7 +39,7 @@ After creation, your collection has four tabs:
    View your collection's unique ID and manage API keys for programmatic access. This tab also links to API documentation if your developers need to integrate with the collection.
 
    <Frame>
-     <img src="/docs/assets/collections/collections-api-tab.png" />
+     <img src="/docs/assets/collections/collections-api-tab.png" alt="API tab showing the collection's unique ID and API key management" />
    </Frame>
 
 3. Preview Semantic Search
@@ -56,7 +56,7 @@ From the Configure tab, scroll to the Data section. You have three main ways to 
 **Public Webpages** — Click the Public Webpages button to add content from publicly accessible web URLs.
 
 <Frame>
-  <img src="/docs/assets/collections/collections-data.png" />
+  <img src="/docs/assets/collections/collections-data.png" alt="Data section with options to search existing sources, upload files, or add public webpages" />
 </Frame>
 
 #### Web Scraping Options
@@ -122,7 +122,7 @@ When enabled, the agent queries every document in each selected collection again
 ### How to Enable
 
 <Frame>
-  <img src="/docs/assets/agents/search-tools/deep-summarize.png" />
+  <img src="/docs/assets/agents/search-tools/deep-summarize.png" alt="Toggle for enabling Deep Summarize on a document collection" />
 </Frame>
 
 **Best Practices**
@@ -149,26 +149,26 @@ Smart Filtering narrows searches to documents matching specific metadata or enti
 1. Enable Smart Filtering:
 
    <Frame>
-     <img src="/docs/assets/agents/search-tools/deep-summarize.png" />
+     <img src="/docs/assets/agents/search-tools/deep-summarize.png" alt="Toggle for enabling Smart Filtering on a document collection" />
    </Frame>
 
 2. Set up your document collection with a [Collection Schema](/user-guide/platform/agent-builder/configuration/add-connectors/document-collections/collection-schemas):
 
    <Frame>
-     <img src="/docs/assets/agents/smart-filters/metadata-schema.png" />
+     <img src="/docs/assets/agents/smart-filters/metadata-schema.png" alt="Collection Schema setup defining metadata fields for a document collection" />
    </Frame>
 
 3. Once you have your schema setup, sync/resync your documents to generate metadata
 
    <Frame>
-     <img src="/docs/assets/agents/smart-filters/extracted-values-example.png" />
+     <img src="/docs/assets/agents/smart-filters/extracted-values-example.png" alt="Example of metadata values extracted from documents after syncing" />
    </Frame>
 
 4. In your agent, make sure to add prompt instructions to filter on metadata.
 
 5. Send a chat, in the action results section you can see what smart filters were applied
    <Frame>
-     <img src="/docs/assets/agents/smart-filters/smart-filtering-example.png" />
+     <img src="/docs/assets/agents/smart-filters/smart-filtering-example.png" alt="Action results in a chat showing which smart filters were applied" />
    </Frame>
 
 ### How does smart filtering work

--- a/fern/docs/pages/platform/agents/configure-steps/connectors/saas.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/connectors/saas.mdx
@@ -5,33 +5,33 @@ title: Actions
 In this section, you can attach one or more **published actions** to the agent. Actions allow agents to dynamically connect to external systems or trigger workflows based on user input.
 
 - Click on **Add Connector** to view all the action providers available to you
-  ![no-attached-actions.png](/docs/assets/actions/no-attached-actions.png)
+  ![The Add Connector button in the connectors section before any actions are attached](/docs/assets/actions/no-attached-actions.png)
 
 - Use the dropdown to search for an action used within a particular tool/integration
-  ![action-provider-selection.png](/docs/assets/actions/action-provider-selection.png)
+  ![The dropdown for searching actions by tool or integration](/docs/assets/actions/action-provider-selection.png)
 
 - Select one or more **read** or **write** published actions
 
   - Read actions will query data and retrieve it for the agent to consume
   - Write actions will take real world action and accomplish tasks within tools
   - Once all the actions are selected click the "Add" button in the bottom right
-    ![action-selection.png](/docs/assets/actions/action-selection.png)
+    ![Selecting read and write published actions with the Add button in the bottom right](/docs/assets/actions/action-selection.png)
 
 - You'll see it show up in the connectors section of the agent configuration
-  ![attached-actions.png](/docs/assets/actions/attached-actions.png)
+  ![Attached actions shown in the connectors section of the agent configuration](/docs/assets/actions/attached-actions.png)
 
 - This is where you can further configure them
 
   - Click on the pencil icon to edit and personalize them
-    ![action-details.png](/docs/assets/actions/action-details.png)
+    ![The pencil icon for editing and personalizing an attached action](/docs/assets/actions/action-details.png)
 
 - When editing the action you can scroll down to modify the parameters of the action. Learn more about [customizing action parameters](/user-guide/platform/governed-actions/action-parameters).
-  ![action-parameters.png](/docs/assets/actions/action-parameters.png)
+  ![The action parameters configuration in the action editor](/docs/assets/actions/action-parameters.png)
 
 - If you scroll even further you'll be able to see the optional human in the loop settings. This setting makes sure that the agent asks for permission every time it needs to take this action. It will wait for the user to approve usage of the action before proceeding.
-  ![action-governance.png](/docs/assets/actions/action-governance.png)
+  ![The human in the loop setting requiring user approval before the action runs](/docs/assets/actions/action-governance.png)
 
 - Once added you'll notice the small orange hammer icon on the action
-  ![action-with-gov-icon.png](/docs/assets/actions/action-with-gov-icon.png)
+  ![An action displaying the small orange hammer icon indicating human in the loop governance](/docs/assets/actions/action-with-gov-icon.png)
 
 Attaching the right actions ensures that your agent can not only respond to questions but also execute real-world tasks across integrated systems.

--- a/fern/docs/pages/platform/agents/configure-steps/prompt.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/prompt.mdx
@@ -4,7 +4,7 @@ title: Prompt
 
 Here you can provide a background prompt, which will provide the agent with context and instructions on how to handle user queries. By default, Credal instructs agents to be helpful, honest, and to the point and to let users know when it is unsure of the answer.
 
-![agent-prompt.png](/docs/assets/agents/create-steps/agent-prompt.png)
+![The background prompt editor in the agent configuration page](/docs/assets/agents/create-steps/agent-prompt.png)
 
 You can revise this prompt to include the background information and instructions relevant to your Agent. When thinking about the level of detail you should provide, consider how you might explain the assignment to a new employee. Your explanation might include:
 
@@ -72,11 +72,11 @@ _--------- End Context ---------_
 
 For instance, in an Agent built to synthesize research reports, you can save prompts like: *Summarize this paper*, *Extract the results*, and *List citations*.
 
-![agent_suggested_questions.png](/docs/assets/agents/create-steps/agent_suggested_questions.png)
+![The Suggested Questions section with saved prompts for an agent](/docs/assets/agents/create-steps/agent_suggested_questions.png)
 
 Turn on the "Enable Suggested Questions in chat" toggle to display them at the chat start screen and above the input box during an active conversation. Users can click any card to auto-populate the prompt in one click and collapse or expand the cards at any time using the toggle button above them.
 
-![agent_saved_suggested_questions.png](/docs/assets/agents/create-steps/agent_saved_suggested_questions.png)
+![Suggested question cards displayed in the chat with the Enable Suggested Questions toggle on](/docs/assets/agents/create-steps/agent_saved_suggested_questions.png)
 
 ---
 
@@ -84,7 +84,7 @@ Turn on the "Enable Suggested Questions in chat" toggle to display them at the c
 
 In the prompt section, you can also provide some model Q&A pairs. This lets the agent know what a good answer looks like. To add a pair, select the "Add Pair" button and insert your question and answer in the pop-out form.
 
-![saved_suggested_questions_display.png](/docs/assets/agents/create-steps/agent_saved_suggested_questions.png)
+![The Add Pair button and form for adding model Q&A pairs](/docs/assets/agents/create-steps/agent_saved_suggested_questions.png)
 
 Your Q&A pairs should reflect the form and depth of response you are looking for. For example, if your agent's job is to review and summarize documents, your model Q&A should include a model example of a summary, showing the type of information that should be included.
 
@@ -152,7 +152,7 @@ Credal has prompt snippets right under the background prompt in the Agent Config
 of telling agents to avoid hallucinations, but can also do things such as improve the total response time of an agent. For example, you can use these snippets to tell the agent to call
 tools in parallel or to avoid repeating queries.
 
-![prompt-snippets.png](/docs/assets/prompt-engineering/prompt-snippets.png)
+![Prompt snippets shown below the background prompt in the Agent Configuration tab](/docs/assets/prompt-engineering/prompt-snippets.png)
 
 ## Complete Example
 
@@ -242,7 +242,7 @@ Encourage concise problem-solving with clear instructions. Instead of asking the
 
 If you're a collaborator on an agent, you can copy-paste your crafted prompts into a Suggested Question in the Agent config. Turn on the "Enable Suggested Questions in chat" toggle so they appear at the chat start screen and above the input box and then users can then reuse a saved prompt with one click.
 
-![prompt-engineering.png](/docs/assets/prompt-engineering/prompt-engineering.png)
+![Saving a crafted prompt as a Suggested Question in the agent config](/docs/assets/prompt-engineering/prompt-engineering.png)
 
 ### Use the Latest Model
 

--- a/fern/docs/pages/platform/agents/configure-steps/prompt.mdx
+++ b/fern/docs/pages/platform/agents/configure-steps/prompt.mdx
@@ -84,8 +84,6 @@ Turn on the "Enable Suggested Questions in chat" toggle to display them at the c
 
 In the prompt section, you can also provide some model Q&A pairs. This lets the agent know what a good answer looks like. To add a pair, select the "Add Pair" button and insert your question and answer in the pop-out form.
 
-![The Add Pair button and form for adding model Q&A pairs](/docs/assets/agents/create-steps/agent_saved_suggested_questions.png)
-
 Your Q&A pairs should reflect the form and depth of response you are looking for. For example, if your agent's job is to review and summarize documents, your model Q&A should include a model example of a summary, showing the type of information that should be included.
 
 ---

--- a/fern/docs/pages/platform/agents/deployment/agents-and-mcp-servers.mdx
+++ b/fern/docs/pages/platform/agents/deployment/agents-and-mcp-servers.mdx
@@ -12,7 +12,7 @@ When you publish an agent to be callable, it becomes available as a tool that MC
 
 2. Enable the **Callable** toggle in the Agents and MCP Servers section to make your agent available as a tool
 
-   ![agent-is-discoverable.png](/docs/assets/agents/deployment/agent-is-discoverable.png)
+   ![Callable toggle in the Agents and MCP Servers section of the Publish tab](/docs/assets/agents/deployment/agent-is-discoverable.png)
 
 3. Configure access permissions:
 

--- a/fern/docs/pages/platform/agents/deployment/api-deployment.mdx
+++ b/fern/docs/pages/platform/agents/deployment/api-deployment.mdx
@@ -1,4 +1,4 @@
 You can connect your agent to other applications or build your own tools that route queries to your agent through a unique API. Use the toggle to enable API access and generate a agent API key.  
 See our [API documentation](/api-reference) for more information on implementation.
 
-![agent-api-deployment.png](/docs/assets/agents/create-steps/agent-api-deployment.png)
+![Toggle for enabling API access and generating an agent API key](/docs/assets/agents/create-steps/agent-api-deployment.png)

--- a/fern/docs/pages/platform/agents/deployment/overview.mdx
+++ b/fern/docs/pages/platform/agents/deployment/overview.mdx
@@ -45,7 +45,7 @@ In the **Publish** tab, you can choose where your agent will be available. Toggl
 - **[Call your Agent via API](/user-guide/platform/agent-builder/publishing-agents/api-deployment)**
   Makes the agent accessible over API using the configured token(s).
 
-![agent-deploy-page.png](/docs/assets/agents/agent-deploy-page.png)
+![Publish tab showing toggles for the available publishing options](/docs/assets/agents/agent-deploy-page.png)
 
 ---
 
@@ -57,7 +57,7 @@ After publishing, your agent will appear under **My Published** in the **Agents*
 - Published agents can be unpublished or updated anytime from the **Publish** tab.
 - Every publish creates a version snapshot you can restore or fork. [Learn more about versions &rarr;](/user-guide/platform/agent-builder/publishing-agents/versions-forking)
 
-![agent-draft-deploy.png](/docs/assets/agents/agent-draft-deploy.png)
+![Published agent listed under My Published in the Agents list](/docs/assets/agents/agent-draft-deploy.png)
 
 ---
 

--- a/fern/docs/pages/platform/agents/deployment/slack-deployment.mdx
+++ b/fern/docs/pages/platform/agents/deployment/slack-deployment.mdx
@@ -36,7 +36,7 @@ When you publish an Agent to a Slack channel, you are adding to a bucket of Agen
 Agent response behaviors:
 
 <Frame>
-  <img src="/docs/assets/agents/routing-options.png" />
+  <img src="/docs/assets/agents/routing-options.png" alt="Routing options for how an agent responds to messages in a Slack channel" />
 </Frame>
 
 1. **Respond to all messages** - The agent tries to help with every message in the channel. If multiple agents have this setting, the agent configured first will respond.
@@ -56,19 +56,19 @@ Agent response behaviors:
 Go to "Slack Channels" in your agents "Publish" settings and enable the ability to talk to your agent in Slack. Then you can select target channels:
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-slack-channel-deploy.png" />
+  <img src="/docs/assets/agents/create-steps/agent-slack-channel-deploy.png" alt="Slack Channels section of the Publish settings with channel selection enabled" />
 </Frame>
 
 If multiple agents are published to a single channel, Credal uses their [Descriptions](/user-guide/platform/agent-builder/configuration/setting-up-an-agent) to determine which should respond.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-slack-trigger-dropdown.png" />
+  <img src="/docs/assets/agents/create-steps/agent-slack-trigger-dropdown.png" alt="Dropdown for choosing which messages trigger the agent in a Slack channel" />
 </Frame>
 
 Example filter setup: respond only to prompts containing `?`.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/relevant-slack-filter.png" />
+  <img src="/docs/assets/agents/create-steps/relevant-slack-filter.png" alt="Example filter configuration that makes the agent respond only to prompts containing a question mark" />
 </Frame>
 
 ---
@@ -80,7 +80,7 @@ Your Credal admin may have configured a Channel Allowlist that restricts which S
 If you need to publish an agent to a channel that isn't in the allowlist, ask your Credal admin to add the channel. Admins can manage the allowlist at [https://app.credal.ai/admin/connectors/slack](https://app.credal.ai/admin/connectors/slack). If you are not on the multi-tenant SaaS Credal offering, replace `https://app.credal.ai` with the URL you typically use to log in to Credal.
 
 <Frame>
-  <img src="/docs/assets/agents/channel_allowlist.png" />
+  <img src="/docs/assets/agents/channel_allowlist.png" alt="Slack channel allowlist management page in the Credal admin connector settings" />
 </Frame>
 
 ---
@@ -94,9 +94,9 @@ Publishing into a private channel works like public channels but requires adding
 3. Click **Add apps to `<YOUR CHANNEL NAME>`**.
 4. Search for **Credal.ai** and click **Add**.
 
-![channel_name_in_slack.png](/docs/assets/agents/create-steps/channel_name_in_slack.png)  
-![integrations.png](/docs/assets/agents/create-steps/integrations.png)  
-![add_apps_to_channel.png](/docs/assets/agents/create-steps/add_apps_to_channel.png)
+![Clicking the private channel name in Slack to open its settings](/docs/assets/agents/create-steps/channel_name_in_slack.png)  
+![Integrations tab in the Slack channel settings](/docs/assets/agents/create-steps/integrations.png)  
+![Adding the Credal.ai app to the Slack channel from the Integrations tab](/docs/assets/agents/create-steps/add_apps_to_channel.png)
 
 ---
 
@@ -116,9 +116,9 @@ Custom bots and the Credal bot behave separately, so if you have both a Custom b
 
 If you have set your agent to respond to "all messages", it will respond to all queries, regardless of whether the question falls within its area of expertise. Here we set Credal's Information Security Copilot to respond to all messages:
 
-![slack_all_messages_query_example.png](/docs/assets/copilots/slack_all_messages_query_example.png)
+![Slack message asking the Information Security Copilot a question unrelated to its expertise](/docs/assets/copilots/slack_all_messages_query_example.png)
 
-![slack_out_of_scope_response.png](/docs/assets/copilots/slack_out_of_scope_response.png)
+![Agent responding that it does not have the context to answer the out-of-scope question](/docs/assets/copilots/slack_out_of_scope_response.png)
 
 > _Because this agent is set to be precise, when asked a question outside its expertise it responds that it does not have the context to answer. If this agent was set to creative, it would rely on its general knowledge to set out the rules of pickleball._
 
@@ -128,11 +128,11 @@ If you have set your agent to respond to only a selection of messages, such as a
 
 Here, we set Credal's Information Security Copilot to only respond to relevant messages:
 
-![*Here, the Agent responded as the question fell within its scope—questions on information security at Credal.*](/docs/assets/copilots/slack_relevant_query_response.png)
+![Here, the Agent responded as the question fell within its scope—questions on information security at Credal.](/docs/assets/copilots/slack_relevant_query_response.png)
 
 _Here, the Agent responded as the question fell within its scope—questions on information security at Credal._
 
-![*This question fell outside of the Agent's scope, and it did not respond.*](/docs/assets/copilots/slack_ignored_query_example.png)
+![This question fell outside of the Agent's scope, and it did not respond.](/docs/assets/copilots/slack_ignored_query_example.png)
 
 _This question fell outside of the Agent's scope, and it did not respond._
 
@@ -143,7 +143,7 @@ _This question fell outside of the Agent's scope, and it did not respond._
 By enabling the advanced settings option, the user will see additional options.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-slack-advance-settings.png" />
+  <img src="/docs/assets/agents/create-steps/agent-slack-advance-settings.png" alt="Advanced settings panel for an agent's Slack publishing options" />
 </Frame>
 
 1. **Thread Response Behavior** – Choose how the agent responds in threads:

--- a/fern/docs/pages/platform/bulk-analysis.mdx
+++ b/fern/docs/pages/platform/bulk-analysis.mdx
@@ -22,7 +22,7 @@ Navigate to the “Document Collection” tab on the left of the Credal UI.
 
 Create a Document Collection and either manually or via API upload data you want to analyze to Credal. This might be sales transcripts as a series of documents, a Jira project, or a folder with meeting notes.
 
-![bulk-analysis-tab.png](/docs/assets/bulk-analysis/in-depth-guide/bulk-analysis-tab.png)
+![Document Collection tab in the Credal sidebar](/docs/assets/bulk-analysis/in-depth-guide/bulk-analysis-tab.png)
 
 ### Using Tabular Data
 
@@ -36,7 +36,7 @@ Create a new Bulk Analysis the same way you would create a new Document Collecti
 
 ### Linking Source Data
 
-![link-source-data.png](/docs/assets/bulk-analysis/in-depth-guide/link-source-data.png)
+![Dialog for linking a Document Collection or spreadsheet as the Bulk Analysis data source](/docs/assets/bulk-analysis/in-depth-guide/link-source-data.png)
 
 Select the Document Collection or Spreadsheet that you want to analyze.
 
@@ -48,25 +48,25 @@ After linking, double check that the rows of the spreadsheet or files in the Doc
 
 This is the heart of Bulk Analysis. Now that you’ve selected a collection/spreadsheet, your Preview table should look something like this:
 
-![preview-table.png](/docs/assets/bulk-analysis/in-depth-guide/preview-table.png)
+![Preview table populated with rows from the linked data source](/docs/assets/bulk-analysis/in-depth-guide/preview-table.png)
 
 If you want to use prompts that already exist as Suggested Questions in an Agent, click "Import Columns" and choose the questions you care about. You can import columns from multiple Agents.
 
-![import-columns.png](/docs/assets/bulk-analysis/in-depth-guide/import-columns.png)
+![Import Columns dialog for choosing Suggested Questions from existing Agents](/docs/assets/bulk-analysis/in-depth-guide/import-columns.png)
 
 Alternatively, you can click on “Add column+” to manually add prompts:
 
-![empty-column-config.png](/docs/assets/bulk-analysis/in-depth-guide/empty-column-config.png)
+![Empty column configuration panel for adding a new prompt column](/docs/assets/bulk-analysis/in-depth-guide/empty-column-config.png)
 
 The column name you assign should concisely describe the content you are extracting from the data. Each column must be configured with an Agent, which will be used to generate the response from the prompt and your document.
 
 Here’s how someone might create a column for generating a cold outbound email based on the attached document. The selected Agent has specific context and a customized background prompt that contains the exact guidelines for how to write a cold email.
 
-![full-column-config.png](/docs/assets/bulk-analysis/in-depth-guide/full-column-config.png)
+![Completed column configuration for generating a cold outbound email with a selected Agent](/docs/assets/bulk-analysis/in-depth-guide/full-column-config.png)
 
 In the end, you'll have a table that looks like this:
 
-![full-preview-table.png](/docs/assets/bulk-analysis/in-depth-guide/full-preview-table.png)
+![Preview table with multiple configured columns each extracting different insights](/docs/assets/bulk-analysis/in-depth-guide/full-preview-table.png)
 
 Notice how each column has a specific detail it’s extracting or content it is generating with a customized assistant!
 
@@ -74,11 +74,11 @@ Notice how each column has a specific detail it’s extracting or content it is 
 
 Writing good prompts is the key to getting meaningful insights from your input data. To write these prompts, it is important to deeply think about what trends and insights you want to uncover from your bulk analysis source data. We highly recommend testing initially with the Suggested Questions feature in the Agent configuration tab.
 
-![suggested-questions.png](/docs/assets/bulk-analysis/in-depth-guide/suggested-questions.png)
+![Suggested Questions feature in the Agent configuration tab](/docs/assets/bulk-analysis/in-depth-guide/suggested-questions.png)
 
 When it comes to what questions you are asking, the choice is yours. You might be summarizing content, generating new content, or answering a simple Yes or No question. Let’s say I am analyzing trends for Jira ticket blockers. To accomplish this, I might want to count for each ticket how many blockers stalled progress on it over the course of its completion and analyze what kinds of tickets experienced more blockers than others. The prompts I’d write would then be:
 
-![example-questions.png](/docs/assets/bulk-analysis/in-depth-guide/example-questions.png)
+![Example prompts for counting and analyzing Jira ticket blockers](/docs/assets/bulk-analysis/in-depth-guide/example-questions.png)
 
 Notice that I do not ask for metadata such as “Assignee” or “Date” since this data is structured data on a ticket. Credal will automatically export that information for you. Now once I run my Bulk Analysis, I have the ability to detect any outliers for # of blockers, access what they were, and understand whether the bottleneck is in the frontend or backend team.
 
@@ -94,7 +94,7 @@ It’s time to run your analysis, which is as easy as clicking a button.
 
 Before running the full analysis, it’s wise to do a preview run on a smaller subset of data. This helps you identify any issues early on. The preview will only display the first 5 documents/rows from your source data which allows you to quickly iterate on your Bulk Analysis configuration. This is a good place to further tweak prompts, adjusting for better quality and output structure.
 
-![running-preview.png](/docs/assets/bulk-analysis/in-depth-guide/running-preview.png)
+![Preview run in progress on the first five rows of source data](/docs/assets/bulk-analysis/in-depth-guide/running-preview.png)
 
 ### Conducting a Full Run
 
@@ -106,7 +106,7 @@ Once satisfied with the preview, proceed to the “Run” tab to conduct a full 
 
 Once you've navigated to the Run tab to do a full Bulk Analysis, you can do one of two things.
 
-![run-tab.png](/docs/assets/bulk-analysis/in-depth-guide/run-tab.png)
+![Run tab with options to chat with results or download a CSV](/docs/assets/bulk-analysis/in-depth-guide/run-tab.png)
 
 ### Chat with Results
 

--- a/fern/docs/pages/platform/integrations/metadata-and-smart-filtering/collection-schemas.mdx
+++ b/fern/docs/pages/platform/integrations/metadata-and-smart-filtering/collection-schemas.mdx
@@ -4,4 +4,4 @@ Collection schemas describe the expected structure of a set of documents, or a s
 
 If you specify that a field “Has a fixed set of values”, then for metadata that is NOT [AI Entity Extracted](/user-guide/platform/agent-builder/configuration/add-connectors/document-collections/ai-entity-extraction-beta), Credal will automatically determine the set of possible values at query time. If there are a large number of entities, Credal may not be able to determine the set of values and may skip this step.
 
-![Metadata Schema Configuration.png](/docs/assets/integrations/metadata-schema-configuration.png)
+![Metadata schema configuration for a document collection showing expected fields and their types](/docs/assets/integrations/metadata-schema-configuration.png)

--- a/fern/docs/pages/platform/mcp-servers/advanced-endpoint.mdx
+++ b/fern/docs/pages/platform/mcp-servers/advanced-endpoint.mdx
@@ -2,7 +2,7 @@
 
 Each MCP server you publish has an **advanced endpoint** available alongside its standard URLs. The advanced endpoint connects to the same server but turns on additional capabilities. You'll find its URL in the Publish tab under Generic MCP Clients — copy it into your MCP client the same way you would any other MCP URL.
 
-![advanced-endpoint](/docs/assets/mcp-servers/advanced-usage/advanced-endpoint.png)
+![Advanced endpoint URL shown under Generic MCP Clients in the Publish tab](/docs/assets/mcp-servers/advanced-usage/advanced-endpoint.png)
 
 ## When to use it
 
@@ -12,13 +12,13 @@ Use the advanced endpoint when you want either of the following.
 
 Actions can be configured to require user approval before they run. These actions only work through the advanced endpoint — on the standard endpoint, they're unavailable.
 
-![human-approval-toggle](/docs/assets/mcp-servers/advanced-usage/human-approval.png)
+![Toggle configuring an action to require user approval before it runs](/docs/assets/mcp-servers/advanced-usage/human-approval.png)
 
 When the user invokes one of these actions, they'll be asked to approve it before it executes:
 
 - If the MCP client supports in-product approval prompts (the MCP "elicitations" feature), the prompt appears directly in the client.
 
-  ![mcp-human-approval](/docs/assets/mcp-servers/advanced-usage/mcp-human-approval.png)
+  ![In-product approval prompt appearing directly in the MCP client](/docs/assets/mcp-servers/advanced-usage/mcp-human-approval.png)
 
 - Otherwise, the user is asked to approve the action in Slack.
 

--- a/fern/docs/pages/platform/mcp-servers/import-server/setting-up-controls.mdx
+++ b/fern/docs/pages/platform/mcp-servers/import-server/setting-up-controls.mdx
@@ -7,8 +7,8 @@ For every MCP server, admins have granular control over which tools are availabl
 
 ![Tool Controls](/docs/assets/actions/mcp-tool-controls.png)
 
-<Note>
-**Tool Syncing:** Credal automatically refreshes the list of available tools every time `tools/list` is called through the MCP gateway. You can also manually refresh tools using the refresh button in the UI.
+<Note title="Tool Syncing">
+Credal automatically refreshes the list of available tools every time `tools/list` is called through the MCP gateway. You can also manually refresh tools using the refresh button in the UI.
 </Note>
 
 ## Agent Access Control

--- a/fern/docs/pages/platform/mcp-servers/import-server/third-party-registration.mdx
+++ b/fern/docs/pages/platform/mcp-servers/import-server/third-party-registration.mdx
@@ -8,19 +8,19 @@ This means your organization gets a single, governed entry point for every MCP s
 
 To get started, make sure you have admin access, then navigate to the **MCP Servers** tab and click **Create New MCP Server**. This time, select **Import a Third-Party MCP Server**.
 
-![import-third-party-server](/docs/assets/mcp-servers/import-server/import-third-party-server.png)
+![Import a Third-Party MCP Server option in the Create New MCP Server menu](/docs/assets/mcp-servers/import-server/import-third-party-server.png)
 
 Give it a name and description, then paste in the server's remote URL.
 
-![third-party-server-details](/docs/assets/mcp-servers/import-server/third-party-server-details.png)
+![Form for entering the third-party server's name, description, and remote URL](/docs/assets/mcp-servers/import-server/third-party-server-details.png)
 
 Credal will walk you through OAuth authentication with the provider to establish the connection.
 
-![oauth-authentication](/docs/assets/mcp-servers/import-server/oauth-authentication.png)
+![OAuth authentication prompt for connecting to the third-party provider](/docs/assets/mcp-servers/import-server/oauth-authentication.png)
 
 Once connected, you'll see a full list of the server's tools, which you can configure and control from that point on.
 
-![third-party-tools-list](/docs/assets/mcp-servers/import-server/third-party-tools-list.png)
+![List of the imported server's tools available for configuration and control](/docs/assets/mcp-servers/import-server/third-party-tools-list.png)
 
 > Credal currently supports OAuth for third-party authentication, with support for user-level private tokens coming in the future.
 

--- a/fern/docs/pages/platform/mcp-servers/mcp-server-builder/attaching-connectors.mdx
+++ b/fern/docs/pages/platform/mcp-servers/mcp-server-builder/attaching-connectors.mdx
@@ -2,7 +2,7 @@
 
 Create and customize actions and data, attach them to your MCP server, and use them from anywhere.
 
-![attaching-connectors-to-server](/docs/assets/mcp-servers/create-steps/attaching-connectors-to-server.png)
+![Attaching action and data connectors to an MCP server](/docs/assets/mcp-servers/create-steps/attaching-connectors-to-server.png)
 
 Attaching data will automatically create and connect a tool called "search_data" - do not remove this tool! If you accidentally do, you can always select it again or it will automatically appear the next time you connect a data source.
 

--- a/fern/docs/pages/platform/mcp-servers/mcp-server-builder/connecting-agents.mdx
+++ b/fern/docs/pages/platform/mcp-servers/mcp-server-builder/connecting-agents.mdx
@@ -4,7 +4,7 @@ Take your most important and relied-upon [agents](/user-guide/platform/agent-bui
 
 Before an agent can be added to an MCP server, it must be published as callable. See [Agents and MCP Servers](/user-guide/platform/agent-builder/publishing-agents/agents-and-mcp-servers) for how to enable the Callable toggle and configure which MCP servers are allowed to invoke it.
 
-![connecting-agents-to-server](/docs/assets/mcp-servers/create-steps/connecting-agents-to-server.png)
+![Adding a published callable agent to an MCP server](/docs/assets/mcp-servers/create-steps/connecting-agents-to-server.png)
 
 Agent calls run asynchronously, so even complex agents that take minutes to complete won't time out. Results are polled automatically in the background using the "Get Job Status" action, which Credal will automatically add when you connect an agent to your MCP Server. Do not remove this action! If you accidentally do, you can always add it back by searching for it.
 

--- a/fern/docs/pages/platform/mcp-servers/mcp-server-builder/create-new-server.mdx
+++ b/fern/docs/pages/platform/mcp-servers/mcp-server-builder/create-new-server.mdx
@@ -4,22 +4,22 @@
 
 To create a new MCP server, navigate to the **MCP Servers** tab in the left sidebar.
 
-![mcp-servers-left-nav](/docs/assets/mcp-servers/create-steps/mcp-servers-left-nav.png)
+![MCP Servers tab in the left sidebar](/docs/assets/mcp-servers/create-steps/mcp-servers-left-nav.png)
 
 ## Create New MCP Server
 
 Click the **Create New MCP Server** button, then select **Create from Scratch**.
 
-![create-mcp-server-button](/docs/assets/mcp-servers/create-steps/create-mcp-server-button.png)
+![Create New MCP Server button with the Create from Scratch option](/docs/assets/mcp-servers/create-steps/create-mcp-server-button.png)
 
 ## Configure Server Details
 
 Give your server a descriptive name and description that makes its purpose clear to the people who will use it.
 
-![mcp-server-creation-modal](/docs/assets/mcp-servers/create-steps/mcp-server-creation-modal.png)
+![Modal for entering the new server's name and description](/docs/assets/mcp-servers/create-steps/mcp-server-creation-modal.png)
 
 ## Server Configuration Page
 
 Once you hit **Create**, you will be redirected to the server's configuration page where you can begin adding data, tools, and agents.
 
-![mcp-server-config-page](/docs/assets/mcp-servers/create-steps/mcp-server-config-page.png)
+![Server configuration page for adding data, tools, and agents](/docs/assets/mcp-servers/create-steps/mcp-server-config-page.png)

--- a/fern/docs/pages/platform/mcp-servers/monitoring-usage.mdx
+++ b/fern/docs/pages/platform/mcp-servers/monitoring-usage.mdx
@@ -6,18 +6,18 @@ Every MCP server session is logged and visible in Credal, regardless of which cl
 
 To view usage, visit the Monitor tab of your Credal or Imported MCP Server.
 
-![server-usage](/docs/assets/mcp-servers/publishing/server-usage.png)
+![Monitor tab showing logged sessions for an MCP server](/docs/assets/mcp-servers/publishing/server-usage.png)
 
 Drill down into specific agent behavior:
 
-![agent-usage](/docs/assets/mcp-servers/publishing/agent-usage.png)
+![Drill-down view of a specific agent's behavior within a session](/docs/assets/mcp-servers/publishing/agent-usage.png)
 
 Drill down into specific action behavior:
 
-![action-usage](/docs/assets/mcp-servers/publishing/action-usage.png)
+![Drill-down view of a specific action's inputs, outputs, and justification](/docs/assets/mcp-servers/publishing/action-usage.png)
 
 ## Version Control
 
 All MCP Server changes are saved as versions, and you can revert to a previous version as needed.
 
-![server-versions](/docs/assets/mcp-servers/publishing/server-versions.png)
+![Version history of an MCP server with the option to revert to a previous version](/docs/assets/mcp-servers/publishing/server-versions.png)

--- a/fern/docs/pages/platform/mcp-servers/publishing-server.mdx
+++ b/fern/docs/pages/platform/mcp-servers/publishing-server.mdx
@@ -9,7 +9,7 @@ To make Credal MCP servers available in Claude or ChatGPT, an admin needs to com
 - **Claude**: `https://app.credal.ai/api/user/claude/mcp`
 - **ChatGPT**: `https://app.credal.ai/api/user/chatgpt/mcp`
 
-![credal-in-claude](/docs/assets/mcp-servers/publishing/credal-in-claude.png)
+![Credal MCP servers available as a connector inside Claude](/docs/assets/mcp-servers/publishing/credal-in-claude.png)
 
 Once connected, all published MCP servers will be available to users in that service without any further configuration.
 
@@ -17,14 +17,14 @@ Once connected, all published MCP servers will be available to users in that ser
 
 Once your MCP server is ready, you have two ways to deploy it. Navigate to the Publish tab where you'll see the following settings:
 
-![fresh-deployment](/docs/assets/mcp-servers/publishing/fresh-deployment.png)
+![Publish tab of an MCP server showing the available deployment settings](/docs/assets/mcp-servers/publishing/fresh-deployment.png)
 
 ### For Claude and ChatGPT
 
 The one-time admin setup above is all that's needed. Your server becomes available to all users in those services automatically once published.
 
 Here is an example of how you can directly publish to all users in ChatGPT
-![full-org-chatgpt](/docs/assets/mcp-servers/publishing/full-org-chatgpt.png)
+![Publishing an MCP server to all users in ChatGPT across the organization](/docs/assets/mcp-servers/publishing/full-org-chatgpt.png)
 
 ### For Other MCP Clients
 
@@ -41,6 +41,6 @@ Regardless of how you publish, MCP server builders can configure end-user allowl
 
 Here is an example of how I would scope visibility down to just one user group. The user group is fetched from your [identity provider](/user-guide/platform/administration/single-sign-on-sso).
 
-![credal-support-chatgpt](/docs/assets/mcp-servers/publishing/credal-support-chatgpt.png)
+![End-user allowlist scoping server visibility in ChatGPT to a single user group](/docs/assets/mcp-servers/publishing/credal-support-chatgpt.png)
 
 Once your server is live, see [Monitoring Usage](/user-guide/platform/managing-mcp-servers/monitoring-usage) to track sessions, inspect action invocations, and review the full audit trail for every tool call.

--- a/fern/docs/pages/platform/mcp-servers/testing-server.mdx
+++ b/fern/docs/pages/platform/mcp-servers/testing-server.mdx
@@ -2,4 +2,4 @@
 
 When testing your server, just deploy to yourself and try it out in whatever surface you prefer. When you feel good about it, open up the allowlist to more folks.
 
-![testing-publish-setup](/docs/assets/mcp-servers/publishing/testing-publish-setup.png)
+![Publish settings with the allowlist scoped to just yourself for testing](/docs/assets/mcp-servers/publishing/testing-publish-setup.png)

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -15,25 +15,25 @@ For example, a Slack agent can listen for benefit-related queries in a channel a
 From the main screen, click **“Agents”** in the navigation menu:
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-left-nav.png" />
+  <img src="/docs/assets/agents/create-steps/agent-left-nav.png" alt="The Agents option in the left navigation menu" />
 </Frame>
 
 Then click **“Create New Agent”**:
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/after-clicking-agent.png" />
+  <img src="/docs/assets/agents/create-steps/after-clicking-agent.png" alt="The Agents page with the Create New Agent button" />
 </Frame>
 
 Give your agent a **Name** and add a **Description** of its function in the pop-out form. You can always edit these later. Descriptions should be detailed enough to explain what types of queries the agent handles.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-creation-popup.png" />
+  <img src="/docs/assets/agents/create-steps/agent-creation-popup.png" alt="The agent creation form with Name and Description fields" />
 </Frame>
 
 You can access all created and shared agents by clicking **“Published”** in the Agents tab.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-published.png" />
+  <img src="/docs/assets/agents/create-steps/agent-published.png" alt="The Published section of the Agents tab listing created and shared agents" />
 </Frame>
 
 ---
@@ -49,13 +49,13 @@ For a deeper walkthrough, see our [Detailed Agents User Guide](/user-guide/platf
 3. **Creativity** – We recommend starting with “Balanced” or “Precise.” Choose “Creative” for open-ended tasks like brainstorming or marketing.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-different-models-dropdown.png" />
+  <img src="/docs/assets/agents/create-steps/agent-different-models-dropdown.png" alt="The model selection dropdown showing available AI models" />
 </Frame>
 
 4. **[Prompt](/user-guide/platform/agent-builder/configuration/writing-instructions)** – Here you can provide a custom prompt that gives the agent context and instructions on how to handle user queries. By default, Credal instructs agents to be helpful, honest, and direct, and to let users know when they're unsure of the answer.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-prompt.png" />
+  <img src="/docs/assets/agents/create-steps/agent-prompt.png" alt="The custom prompt editor in the agent configuration page" />
 </Frame>
 
 You can revise this prompt to include the background information and instructions relevant to your agent. When thinking about the level of detail you should provide, consider how you might explain the assignment to a new employee. Your explanation might include:
@@ -107,7 +107,7 @@ _--------- End Context ---------_
      For the most important sources, you may want to "Bookmark" these sources by clicking the yellow pin icon as shown below. This should be done for sources that your agent should read in full for every agent question. Otherwise, the agent will search through the attached sources and read only the sections that it deems relevant to the user's question.
 
      <Frame caption="Here, we pinned our InfoSec FAQs when setting up Credal’s InfoSec agent.">
-       <img src="/docs/assets/agents/create-steps/agent-datasource-configure.png" />
+       <img src="/docs/assets/agents/create-steps/agent-datasource-configure.png" alt="Attached data sources with a bookmarked source pinned via the yellow pin icon" />
      </Frame>
 
    - **User Inputs / Attachments**
@@ -128,14 +128,14 @@ This guide covers Slack. For other integrations, see the [full documentation](/u
 Go to "Slack Channels" in your agents "Publish" settings and enable the ability to talk to your agent in Slack. Then you can select target channels:
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-slack-channel-deploy.png" />
+  <img src="/docs/assets/agents/create-steps/agent-slack-channel-deploy.png" alt="The Slack Channels publish settings for selecting target channels" />
 </Frame>
 
 If multiple agents are published to a single channel, Credal uses their descriptions to decide which one should respond.
 You can choose to have your agent answer all messages in a given channel or only those that meet certain criteria:
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-slack-configure.png" />
+  <img src="/docs/assets/agents/create-steps/agent-slack-configure.png" alt="Slack configuration options for choosing which messages the agent answers" />
 </Frame>
 
 - **All messages**: will answer all queries in the connected Slack channel.
@@ -143,13 +143,13 @@ You can choose to have your agent answer all messages in a given channel or only
 - **All messages matching filter**: will respond to messages that match the filter criteria. In the example in the screenshot, the agent will only respond to prompts containing “?”.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/agent-slack-trigger-dropdown.png" />
+  <img src="/docs/assets/agents/create-steps/agent-slack-trigger-dropdown.png" alt="The Slack trigger dropdown with a filter matching messages containing a question mark" />
 </Frame>
 
 If more than one agent is published to a given Slack channel, Credal will triage user requests based on the Description of each agent to determine which, if any, should answer the question.
 
 <Frame>
-  <img src="/docs/assets/agents/create-steps/relevant-slack-filter.png" />
+  <img src="/docs/assets/agents/create-steps/relevant-slack-filter.png" alt="Multiple agents published to one Slack channel, triaged by their descriptions" />
 </Frame>
 
 </Steps>

--- a/fern/docs/pages/tutorials/salesforce-query/salesforce-example.mdx
+++ b/fern/docs/pages/tutorials/salesforce-query/salesforce-example.mdx
@@ -42,7 +42,7 @@ See a demo of the Salesforce Query Assistant in action:
   width="560"
   height="315"
   src="https://www.youtube.com/embed/l7Dofe68yuQ?si=VseZjyBY7gskYTme"
-  title="YouTube video player"
+  title="Video: Demo of the Salesforce Query Assistant answering questions with SOQL queries"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerpolicy="strict-origin-when-cross-origin"

--- a/fern/docs/pages/tutorials/slack-workflows/slack-workflows.mdx
+++ b/fern/docs/pages/tutorials/slack-workflows/slack-workflows.mdx
@@ -5,6 +5,7 @@ Credal now supports triggering agents via Slack Workflows — on a schedule or b
 <div style={{ position: "relative", paddingBottom: "56.25%", height: 0 }}>
   <iframe
     src="https://www.loom.com/embed/4515a790e2c84bab995a335b821cfd41"
+    title="Video: Connecting a Credal agent to a Slack Workflow"
     frameBorder="0"
     allowFullScreen
     style={{
@@ -27,7 +28,7 @@ Before setting up a Slack Workflow trigger, your agent must already be published
 
 In your agent's **Publish** settings, go to **Slack Channels**, enable **Talk to your agent in Slack**, and add the agent to the channel where your Slack Workflow will post.
 
-<Callout intent="info">
+<Callout intent="info" title="Message structure matters">
   Make sure the body text of your Slack Workflow message is structured to
   trigger the agent correctly based on your agent's routing settings (e.g.
   matching a filter, or triggering on all messages).
@@ -38,7 +39,7 @@ In your agent's **Publish** settings, go to **Slack Channels**, enable **Talk to
 In Slack, open your workflow and copy the Workflow ID. The agent will respond in the thread of the workflow message rather than posting directly to the channel.
 
 <Frame>
-  <img src="/docs/assets/copilots/inside-slack-copy-workflow-id.png" />
+  <img src="/docs/assets/copilots/inside-slack-copy-workflow-id.png" alt="Slack workflow details showing where to copy the Workflow ID" />
 </Frame>
 
 ### Step 3: Enable "Respond to Slack Workflows"
@@ -46,7 +47,7 @@ In Slack, open your workflow and copy the Workflow ID. The agent will respond in
 In the same Slack publishing settings, toggle on **Respond to Slack Workflows**, then paste in your Workflow ID.
 
 <Frame>
-  <img src="/docs/assets/copilots/link-workflow-id-to-channel-deployment.png" />
+  <img src="/docs/assets/copilots/link-workflow-id-to-channel-deployment.png" alt="Slack publishing settings with the Respond to Slack Workflows toggle enabled and a Workflow ID pasted in" />
 </Frame>
 
 ## Example use cases

--- a/fern/docs/pages/tutorials/snowflake-query/initial-setup.mdx
+++ b/fern/docs/pages/tutorials/snowflake-query/initial-setup.mdx
@@ -44,7 +44,7 @@ GRANT ROLE CREDAL_READ TO USER CREDAL_USER;
 
 - They will need the `Subdomain`, `Account Identifier`, `Username`, `Private Key` and `SHA-256 Fingerprint` to add the snowflake connection.
   <Frame>
-    <img src="/docs/assets/agents/snowflake-query/snowflake-add-credential.png" />
+    <img src="/docs/assets/agents/snowflake-query/snowflake-add-credential.png" alt="Form for adding a Snowflake credential with fields for subdomain, account identifier, username, private key, and SHA-256 fingerprint" />
   </Frame>
 
 ## Implementation Steps
@@ -59,7 +59,7 @@ GRANT ROLE CREDAL_READ TO USER CREDAL_USER;
    > Output from the runSnowflakeQuery Action is passed into Open AI Code Interpreter for image generation and analysis (depending on your parameter setup)
 
 <Frame>
-  <img src="/docs/assets/agents/search-tools/code-interpreter.png" />
+  <img src="/docs/assets/agents/search-tools/code-interpreter.png" alt="Agent configuration panel with the Code Interpreter option enabled" />
 </Frame>
 
 **Tip:** A detailed description helps users understand the purpose of your Agent.
@@ -89,10 +89,10 @@ Access to Snowflake data is controlled at two levels:
 **Important Security Note**: Any user with end-user access to an Action will be able to use the attached Snowflake credentials through that Action. Ensure you carefully manage the End User Access list to maintain proper data security.
 
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/action-credential.png" />
+  <img src="/docs/assets/agents/snowflake-query/action-credential.png" alt="Action settings showing a Snowflake credential attached to the action" />
 </Frame>
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/end-user-access.png" />
+  <img src="/docs/assets/agents/snowflake-query/end-user-access.png" alt="End User Access settings specifying which users and groups can use the action" />
 </Frame>
 
 ### Step 4: Model Choice

--- a/fern/docs/pages/tutorials/snowflake-query/query-approaches.mdx
+++ b/fern/docs/pages/tutorials/snowflake-query/query-approaches.mdx
@@ -17,7 +17,7 @@ The way query templates work is by using [embedded parameters](/user-guide/platf
 3.  **Action Example Params:**
 
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/query-param-template.png" />
+  <img src="/docs/assets/agents/snowflake-query/query-param-template.png" alt="Example action parameters for a query template with embedded parameters the AI fills in" />
 </Frame>
 
 **Note:** An agent will use the action name and description to decide to run an action - make sure these are good descriptions of what the action does. Currently each query template requires its own runSnowflakeQuery action - meaning your agent will have multiple actions attached.
@@ -39,7 +39,7 @@ This relies on the user uploading table metadata to the agents data sources to e
 3.  **Action Example Params:**
 
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/query-param-views.png" />
+  <img src="/docs/assets/agents/snowflake-query/query-param-views.png" alt="Example action parameters for the Snowflake views approach with a generic query parameter" />
 </Frame>
 
 **Note:** Since you'll only have one runSnowflake action attached to your agent with the views approach - the name and description must be more generic.
@@ -75,7 +75,7 @@ This is just an example of how to give the **Snowflake Query Agent** context on 
 4.  Attach your generated csv of table schema data (ensure file is named appropriately e.g Snowflake Table Schemas)
 
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/data-sources-setup.png" />
+  <img src="/docs/assets/agents/snowflake-query/data-sources-setup.png" alt="Agent configuration Data Sources section with a Snowflake table schemas CSV attached" />
 </Frame>
 
 **Tip:** Remember Google Drive uploads will only be visible/usable in the Agent users who have access to it in Google Drive (Permissions are mirrored) - to avoid this you can upload a csv file instead of a Google Sheets link

--- a/fern/docs/pages/tutorials/snowflake-query/testing-solution.mdx
+++ b/fern/docs/pages/tutorials/snowflake-query/testing-solution.mdx
@@ -27,7 +27,7 @@ Now that we've tested something basic, we can test out our Snowflake Agent.
 - The image generated comes from Open AI Code Interpreter.
 
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/snowflake-views-approach.png" />
+  <img src="/docs/assets/agents/snowflake-query/snowflake-views-approach.png" alt="Agent response using the views approach, showing the query results and a generated chart" />
 </Frame>
 
 #### Example Action Output
@@ -36,7 +36,7 @@ Now that we've tested something basic, we can test out our Snowflake Agent.
 - **Debugging Tip**: the steps tab is not shown if an action was not run
 
 <Frame>
-  <img src="/docs/assets/agents/snowflake-query/snowflake-action-result.png" />
+  <img src="/docs/assets/agents/snowflake-query/snowflake-action-result.png" alt="Steps tab showing the Snowflake action's parameters and query output" />
 </Frame>
 
 ### Need Help?


### PR DESCRIPTION
**Context**
An accessibility audit (WCAG 2.1 AA / VPAT prep) found that most screenshots in the docs had missing or filename-style alt text, several video embeds lacked titles, untitled callouts rendered blank headings, and the light-mode accent color failed the AA contrast minimum. This PR fixes everything addressable in this repo; remaining issues in Fern's platform-rendered UI (unlabeled copy/theme/page-action buttons) are being reported to Fern separately.

**Summary**
- Alt text: added or rewrote descriptive alt text for ~125 images across 38 MDX files
- Iframe titles: added titles to 4 Loom embeds; replaced generic YouTube titles with descriptive ones
- Empty headings: added title props to 8 untitled <Callout>/<Note> components 
- Contrast: light-mode accent #228be6 (3.56:1, fail) → #1971c2 (5.0:1, pass); kept #228be6 for dark mode

**Testing:**
Ran it locally with the WAVE Chrome extension on to test whether the changes reduced the amount of errors. Almost all were however some require changes on Fern's end.

Added a Loom to show examples:
https://www.loom.com/share/9862e89c39eb4866b4fe72b9fc63d87b

NOTE: Some errors need to be resolved by Fern themselves, for example the copy code pop up button on code snippets and some buttons in the header